### PR TITLE
Add easy plotting for cohorts

### DIFF
--- a/cohorts/count.py
+++ b/cohorts/count.py
@@ -1,0 +1,66 @@
+# Copyright (c) 2016. Mount Sinai School of Medicine
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import pandas as pd
+
+from varcode import EffectCollection
+from varcode.effects import Substitution
+
+def snv_count(cohort):
+    sample_variants = cohort.load_variants()
+    def count_func(sample):
+        if sample in sample_variants:
+            return len(sample_variants[sample])
+        return np.nan
+    return count(cohort, count_func, count_col="snv_count")
+
+def nonsynonymous_snv_count(cohort):
+    sample_nonsynonymous_effects = cohort.load_effects(only_nonsynonymous=True)
+    def count_func(sample):
+        if sample in sample_nonsynonymous_effects:
+            return len(sample_nonsynonymous_effects[sample])
+        return np.nan
+    return count(cohort, count_func, count_col="nonsynonymous_snv_count")
+
+def missense_snv_count(cohort):
+    sample_nonsynonymous_effects = cohort.load_effects(only_nonsynonymous=True)
+    sample_missense_effects = dict(
+        [(sample,
+          EffectCollection(
+              [effect for effect in effects if type(effect) == Substitution]))
+         for (sample, effects) in sample_nonsynonymous_effects.items()])
+    def count_func(sample):
+        if sample in sample_missense_effects:
+            return len(sample_missense_effects[sample])
+        return np.nan
+    return count(cohort, count_func, count_col="missense_snv_count")
+
+def neoantigen_count(cohort):
+    sample_neoantigens = cohort.load_neoantigens()
+    def count_func(sample):
+        if sample in sample_neoantigens["sample_id"].unique():
+            return len(sample_neoantigens[sample_neoantigens["sample_id"] == sample])
+        return np.nan
+    return count(cohort, count_func, count_col="neoantigen_count")
+
+def count(cohort, count_func, count_col):
+    df = cohort.clinical_dataframe.copy()
+    df[count_col] = df[cohort.clinical_dataframe_id_col].map(count_func)
+    original_len = len(df)
+    df = df[~df[count_col].isnull()]
+    updated_len = len(df)
+    if updated_len < original_len:
+        print("Missing count for %d samples: from %d to %d" % (original_len - updated_len, original_len, updated_len))
+    return count_col, df

--- a/cohorts/count.py
+++ b/cohorts/count.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import print_function
+
 import numpy as np
 import pandas as pd
 

--- a/cohorts/load.py
+++ b/cohorts/load.py
@@ -252,7 +252,8 @@ class Cohort(object):
         self.clear_cache(self.neoantigen_cache_name)
 
     def clinical_columns(self):
-        return list(self.clinical_dataframe.columns)
+        column_types = [self.clinical_dataframe[col].dtype for col in self.clinical_dataframe.columns]
+        return dict(zip(list(self.clinical_dataframe.columns), column_types))
 
     def plot_init(self, on, col, col_equals):
         """

--- a/cohorts/load.py
+++ b/cohorts/load.py
@@ -273,7 +273,7 @@ class Cohort(object):
     def plot_benefit(self, on, col=None, col_equals=None):   
         plot_col, df = self.plot_init(on, col, col_equals)
         original_len = len(df)
-        df = df[~df[self.benefit_col].isnull()]
+        df = df[df[self.benefit_col].notnull()]
         updated_len = len(df)
         df[self.benefit_col] = df[self.benefit_col].apply(bool)
         if updated_len < original_len:

--- a/cohorts/load.py
+++ b/cohorts/load.py
@@ -18,7 +18,7 @@ from os import path, makedirs
 from shutil import rmtree
 import pandas as pd
 import numpy as np
-import pickle
+import six.moves.cPickle as pickle
 import sys
 from types import FunctionType
 

--- a/cohorts/load.py
+++ b/cohorts/load.py
@@ -251,6 +251,9 @@ class Cohort(object):
     def clear_neoantigen_cache(self):
         self.clear_cache(self.neoantigen_cache_name)
 
+    def clinical_columns(self):
+        return list(self.clinical_dataframe.columns)
+
     def plot_init(self, on, col, col_equals):
         """
         `on` is either:

--- a/cohorts/load.py
+++ b/cohorts/load.py
@@ -262,7 +262,7 @@ class Cohort(object):
             return on(self)
         if type(on) == str:
             if on in self.clinical_dataframe.columns:
-                return (on, self.clinical_dataframe())
+                return (on, self.clinical_dataframe)
             else:
                 return col_func(self, on, col, col_equals)
 

--- a/cohorts/load.py
+++ b/cohorts/load.py
@@ -17,12 +17,19 @@ from __future__ import print_function
 from os import path, makedirs
 from shutil import rmtree
 import pandas as pd
+import numpy as np
 import pickle
+import sys
+from types import FunctionType
 
 import varcode
-from varcode import VariantCollection
+from varcode import VariantCollection, EffectCollection
 from mhctools import NetMHCcons
 from topiary import predict_epitopes_from_variants, epitopes_to_dataframe
+
+from .survival import plot_kmf
+from .plot import mann_whitney_plot, fishers_exact_plot
+from .count import count, snv_count, neoantigen_count
 
 class Cohort(object):
     """Represents a cohort of patients."""
@@ -33,6 +40,13 @@ class Cohort(object):
                  sample_ids,
                  normal_bam_ids,
                  tumor_bam_ids,
+                 clinical_dataframe=None,
+                 clinical_dataframe_id_col=None,
+                 benefit_col=None,
+                 os_col=None,
+                 pfs_col=None,
+                 dead_col=None,
+                 progressed_col=None,
                  hla_alleles=None,
                  cache_results=True,
                  snv_file_format_funcs=None,
@@ -41,6 +55,13 @@ class Cohort(object):
         self.cache_dir = cache_dir
         self.normal_bam_ids = normal_bam_ids
         self.tumor_bam_ids = tumor_bam_ids
+        self.clinical_dataframe = clinical_dataframe
+        self.clinical_dataframe_id_col = clinical_dataframe_id_col
+        self.benefit_col = benefit_col
+        self.os_col = os_col
+        self.pfs_col = pfs_col
+        self.dead_col = dead_col
+        self.progressed_col = progressed_col
         self.hla_alleles = hla_alleles
         self.cache_results = cache_results
         self.snv_file_format_funcs = snv_file_format_funcs
@@ -55,6 +76,8 @@ class Cohort(object):
         self.variant_type_to_format_funcs = variant_type_to_format_funcs
 
         self.variant_cache_name = "cached-variants"
+        self.effect_cache_name = "cached-effects"
+        self.nonsynonymous_effect_cache_name = "cached-nonsynonymous-effects"
         self.neoantigen_cache_name = "cached-neoantigens"
 
     def load_from_cache(self, cache_name, sample_id, file_name):
@@ -137,6 +160,39 @@ class Cohort(object):
 
         return merged_variants
 
+    def load_effects(self, only_nonsynonymous=False, variant_type="snv", merge_type="union"):
+        sample_effects = {}
+        for i, sample_id in enumerate(self.sample_ids):
+            effects = self._load_single_sample_effects(
+                i, self.variant_type_to_format_funcs, only_nonsynonymous, variant_type, merge_type)
+            sample_effects[sample_id] = effects
+        return sample_effects
+
+    def _load_single_sample_effects(self, sample_idx, file_format_funcs,
+                                    only_nonsynonymous, variant_type, merge_type):
+        sample_id = self.sample_ids[sample_idx]
+
+        cached_file_name = "%s-%s-effects.pkl" % (variant_type, merge_type)
+        if only_nonsynonymous:
+            cached = self.load_from_cache(self.nonsynonymous_effect_cache_name, sample_id, cached_file_name)
+        else:
+            cached = self.load_from_cache(self.effect_cache_name, sample_id, cached_file_name)
+        if cached is not None:
+            return cached
+
+        variants = self._load_single_sample_variants(
+            sample_idx, self.variant_type_to_format_funcs[variant_type], variant_type, merge_type)
+        effects = variants.effects()
+        nonsynonymous_effects = EffectCollection(
+            effects.drop_silent_and_noncoding().top_priority_effect_per_variant().values())
+
+        self.save_to_cache(effects, self.effect_cache_name, sample_id, cached_file_name)
+        self.save_to_cache(nonsynonymous_effects, self.nonsynonymous_effect_cache_name, sample_id, cached_file_name)
+
+        if only_nonsynonymous:
+            return nonsynonymous_effects
+        return effects
+
     def load_neoantigens(self, variant_type="snv", merge_type="union",
                          epitope_lengths=[8, 9, 10, 11], ic50_cutoff=500,
                          process_limit=10, max_file_records=None):
@@ -194,3 +250,57 @@ class Cohort(object):
 
     def clear_neoantigen_cache(self):
         self.clear_cache(self.neoantigen_cache_name)
+
+    def plot_init(self, on, col, col_equals):
+        """
+        `on` is either:
+        - a function that creates a new column for comparison, e.g. count.snv_count
+        - a string representing an existing column
+        - a string representing a new column name, created by comparing column `col` with the value `col_equals`
+        """
+        if type(on) == FunctionType:
+            return on(self)
+        if type(on) == str:
+            if on in self.clinical_dataframe.columns:
+                return (on, self.clinical_dataframe())
+            else:
+                return col_func(self, on, col, col_equals)
+
+    def plot_benefit(self, on, col=None, col_equals=None):   
+        plot_col, df = self.plot_init(on, col, col_equals)
+        original_len = len(df)
+        df = df[~df[self.benefit_col].isnull()]
+        updated_len = len(df)
+        df[self.benefit_col] = df[self.benefit_col].apply(bool)
+        if updated_len < original_len:
+            print("Missing benefit for %d samples: from %d to %d" % (original_len - updated_len, original_len, updated_len))
+        if df[plot_col].dtype == "bool":    
+            results = fishers_exact_plot(
+                data=df,
+                condition1=self.benefit_col,
+                condition2=plot_col)
+        else:
+            results = mann_whitney_plot(
+                data=df,
+                condition=self.benefit_col,
+                distribution=plot_col)
+
+    def plot_survival(self, on, col=None, col_equals=None, how="os", threshold=None):
+        assert how in ["os", "pfs"]
+        plot_col, df = self.plot_init(on, col, col_equals)
+        if df[plot_col].dtype == "bool":    
+            default_threshold = None
+        else:
+            default_threshold = "median"
+        results = plot_kmf(
+            df=df,
+            condition_col=plot_col,
+            censor_col=self.dead_col if how == "os" else self.progressed_col,
+            survival_col=self.os_col if how == "os" else self.pfs_col,
+            threshold=threshold if threshold is not None else default_threshold)
+        print(results)
+                    
+def col_func(cohort, on, col, col_equals):
+    df = cohort.clinical_dataframe.copy()
+    df[on] = df[col] == col_equals
+    return on, df

--- a/cohorts/plot.py
+++ b/cohorts/plot.py
@@ -1,0 +1,85 @@
+# Copyright (c) 2016. Mount Sinai School of Medicine
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+from scipy.stats import mannwhitneyu, fisher_exact
+import seaborn as sb
+import pandas as pd
+
+def fishers_exact_plot(data, condition1, condition2):
+    """
+    Perform a Fisher's exact test to compare to binary columns
+
+    Parameters
+    ----------
+    data: Pandas dataframe
+        Dataframe to retrieve information from
+
+    condition1: str
+        First binary column compare
+
+    condition2: str
+        Second binary column to compare
+    """
+    sb.factorplot(
+        x=condition1,
+        y=condition2,
+        kind='bar',
+        data=data
+    )
+    count_table = pd.crosstab(data[condition1], data[condition2])
+    print(count_table)
+    oddsratio, pvalue = fisher_exact(count_table)
+    print("Fisher's Exact Test: OR: {}, p-value={}".format(oddsratio, pvalue))
+    return (oddsratio, pvalue)
+
+def mann_whitney_plot(data, condition, distribution, condition_value=None):
+    """
+    Create a box plot comparing a condition and perform a
+    Mann Whitney test to compare the distribution in condition A v B
+
+    Parameters
+    ----------
+    data: Pandas dataframe
+        Dataframe to retrieve information from
+
+    condition: str
+        Column to use as the splitting criteria
+
+    distribution: str
+        Column to use as the Y-axis or distribution in the test
+
+    condition_value:
+        If `condition` is not a binary column, split on =/!= to condition_value
+    """
+
+    sb.factorplot(
+        x=condition,
+        y=distribution,
+        kind='box',
+        data=data
+    )
+
+    if condition_value:
+        condition_mask = data[condition] == condition_value
+    else:
+        condition_mask = data[condition]
+    U, pvalue = mannwhitneyu(
+        data[condition_mask][distribution],
+        data[~condition_mask][distribution],
+    )
+
+    print("Mann-Whitney test: U={}, p-value={}".format(U, pvalue))
+    return (U, pvalue)

--- a/cohorts/survival.py
+++ b/cohorts/survival.py
@@ -1,0 +1,118 @@
+# Copyright (c) 2016. Mount Sinai School of Medicine
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+from lifelines import KaplanMeierFitter
+from lifelines.statistics import logrank_test
+
+def plot_kmf(df, 
+             condition_col, 
+             censor_col, 
+             survival_col, 
+             threshold=None,
+             title=None,
+             xlabel=None,
+             ax=None,
+             print_as_title=False):
+    """
+    Plot survival curves by splitting the dataset into two groups based on
+    condition_col
+
+    if threshold is defined, the groups are split based on being > or <
+    condition_col
+
+    if threshold == 'median', the threshold is set to the median of condition_col
+
+    Parameters
+    ----------
+        df: dataframe
+        condition_col: string, column which contains the condition to split on
+        survival_col: string, column which contains the survival time
+        censor_col: string,
+        threshold: int or string, if int, condition_col is thresholded,
+                                  if 'median', condition_col thresholded 
+                                  at its median
+        title: Title for the plot, default None
+        ax: an existing matplotlib ax, optional, default None
+        print_as_title: bool, optional, whether or not to print text
+          within the plot's title vs. stdout, default False
+    """
+    kmf = KaplanMeierFitter()
+    if threshold is not None:
+        if threshold == 'median':
+            threshold = df[condition_col].median()
+        condition = df[condition_col] > threshold
+        label = '{} > {}'.format(condition_col, threshold)
+    else:
+        condition = df[condition_col]
+        label = '{}'.format(condition_col)
+                       
+    df_with_condition = df[condition]
+    df_no_condition = df[~condition]
+    survival_no_condition = df_no_condition[survival_col]
+    survival_with_condition = df_with_condition[survival_col]
+
+    event_no_condition = (df_no_condition[censor_col].astype(bool))
+    event_with_condition = (df_with_condition[censor_col].astype(bool))
+                  
+    kmf.fit(survival_no_condition, event_no_condition, label="")
+    if ax:
+        kmf.plot(ax=ax, show_censors=True, ci_show=False)
+    else:
+        ax = kmf.plot(show_censors=True, ci_show=False)
+
+    kmf.fit(survival_with_condition, event_with_condition, label=(label))
+    kmf.plot(ax=ax, show_censors=True, ci_show=False)
+
+    no_cond_str = "# no condition {}".format(len(survival_no_condition))
+    cond_str = "# with condition {}".format(len(survival_with_condition))
+    if title:
+        ax.set_title(title)
+    elif print_as_title:
+        ax.set_title("%s | %s" % (no_cond_str, cond_str))
+    else:
+        print(no_cond_str)
+        print(cond_str)
+
+    if xlabel:
+        ax.set_xlabel(xlabel)
+ 
+    results = logrank_test(survival_no_condition, 
+                           survival_with_condition, 
+                           event_observed_A=event_no_condition, 
+                           event_observed_B=event_with_condition)
+    return results
+
+def logrank(df,
+            condition_col,
+            censor_col,
+            survival_col,
+            threshold=None):
+    if threshold is not None:
+        if threshold == 'median':
+            threshold = df[condition_col].median()
+        condition = df[condition_col] > threshold
+    else:
+        condition = df[condition_col]
+    df_with_condition = df[condition]
+    df_no_condition = df[~condition]
+    survival_no_condition = df_no_condition[survival_col]
+    survival_with_condition = df_with_condition[survival_col]
+    event_no_condition = (df_no_condition[censor_col].astype(bool))
+    event_with_condition = (df_with_condition[censor_col].astype(bool))
+    return logrank_test(survival_no_condition, 
+                        survival_with_condition, 
+                        event_observed_A=event_no_condition, 
+                        event_observed_B=event_with_condition)

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,8 @@ if __name__ == "__main__":
             "pandas>=0.15",
             "seaborn>=0.7.0",
             "scipy>=0.16.1",
-            "topiary>=0.0.15"
+            "topiary>=0.0.15",
+            "six>=1.10.0",
         ],
         long_description=readme,
         packages=["cohorts"],

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ except ImportError as e:
 if __name__ == "__main__":
     setup(
         name="cohorts",
-        version="0.0.0",
+        version="0.0.1",
         description="Utilities for analyzing mutations and neoepitopes in patient cohorts",
         author="Tavi Nathanson",
         author_email="tavi {dot} nathanson {at} gmail {dot} com",
@@ -56,7 +56,9 @@ if __name__ == "__main__":
             "Topic :: Scientific/Engineering :: Bio-Informatics",
         ],
         install_requires=[
-            "pandas>=0.15", 
+            "pandas>=0.15",
+            "seaborn>=0.7.0",
+            "scipy>=0.16.1",
             "topiary>=0.0.15"
         ],
         long_description=readme,


### PR DESCRIPTION
`Plotting a KM curve is as simple as`cohort.plot_survival(snv_count)`. To be actually useful, I imagine it'll need a bunch more tweaking (e.g. easy filtering of the dataset).

Also added basic clinical data handling; it'll need more work, e.g. `pfs` isn't good enough to describe two different measures of progression-free survival.
