### PR TITLE
Add lifelines as a dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ if __name__ == "__main__":
             "scipy>=0.16.1",
             "topiary>=0.0.15",
             "six>=1.10.0",
+            "lifelines>=0.9.1.0,"
         ],
         long_description=readme,
         packages=["cohorts"],


### PR DESCRIPTION
Otherwise, we get this:

```
---------------------------------------------------------------------------
ImportError                               Traceback (most recent call last)
<ipython-input-2-526f834766b3> in <module>()
      2 from os import getcwd, path
      3 sys.path.append(path.dirname(getcwd()))
----> 4 from utils import data
      5 
      6 cohort = data.init_cohort(cache_data_dir="/tmp/cache")

/Users/arman/Projects/bladder-analyses/analyses/utils/data.py in <module>()
      2 from os import path, getcwd, environ
      3 
----> 4 from cohorts import Cohort
      5 
      6 # This repo's "data" directory

/Users/arman/miniconda2/envs/env/lib/python2.7/site-packages/cohorts/__init__.py in <module>()
     13 # limitations under the License.
     14 
---> 15 from .load import *

/Users/arman/miniconda2/envs/env/lib/python2.7/site-packages/cohorts/load.py in <module>()
     28 from topiary import predict_epitopes_from_variants, epitopes_to_dataframe
     29 
---> 30 from .survival import plot_kmf
     31 from .plot import mann_whitney_plot, fishers_exact_plot
     32 from .count import count, snv_count, neoantigen_count

/Users/arman/miniconda2/envs/env/lib/python2.7/site-packages/cohorts/survival.py in <module>()
     15 from __future__ import print_function
     16 
---> 17 from lifelines import KaplanMeierFitter
     18 from lifelines.statistics import logrank_test
     19 

ImportError: No module named lifelines
```
