### PR TITLE
Refactor cohorts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,11 +33,6 @@ install:
   - pip install -r requirements.txt
   - pip install .
   - pip install coveralls
-before_script:
-  # Imitate a display to allow for matplotlib plotting
-  - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"
-  - sleep 3 # give xvfb some time to start
 script:
   - pyensembl install --release 75 --species human
   - nosetests test --with-coverage --cover-package=cohorts && ./lint.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,11 @@ install:
   - pip install -r requirements.txt
   - pip install .
   - pip install coveralls
+before_script:
+  # Imitate a display to allow for matplotlib plotting
+  - "export DISPLAY=:99.0"
+  - "sh -e /etc/init.d/xvfb start"
+  - sleep 3 # give xvfb some time to start
 script:
   - pyensembl install --release 75 --species human
   - nosetests test --with-coverage --cover-package=cohorts && ./lint.sh

--- a/README.md
+++ b/README.md
@@ -20,41 +20,56 @@ Usage Examples
 --------------
 
 ```python
+patient_1 = Patient(
+    id="patient_1",
+    os=70,
+    pfs=24,
+    deceased=True,
+    progressed=True,
+    benefit=False)
+patient_2 = Patient(
+    id="patient_2",
+    os=100,
+    pfs=50,
+    deceased=False,
+    progressed=True,
+    benefit=False)
+)
 cohort = Cohort(
-    data_dir="/my/input/data",
-    cache_dir="/where/cohorts/results/get/saved",
-    sample_ids=["sample_1", "sample_2"],
-    clinical_dataframe=pandas_dataframe_with_clinical_data,
-    clinical_dataframe_id_col="sample_id_in_dataframe",
-    os_col="Overall Survival",
-    pfs_col="Progression-Free Survival",
-    deceased_col="deceased",
-    progressed_or_deceased_col="progressed_or_deceased"
+    patients=[patient_1, patient_2],
+    cache_dir="/where/cohorts/results/get/saved"
 )
 
 cohort.plot_survival(how="os")
 ```
 
 ```python
-def mutect_snv_file_format_func(sample_id, normal_bam_id, tumor_bam_id):
-    return "Mutect-%d-normal=%s.bam-tumor=%s.bam-merged.vcf" % (
-        sample_id, normal_bam_id, tumor_bam_id)
-
-def strelka_snv_file_format_func(...):
+sample_1_tumor = Sample(
+    id="sample_1_tumor",
+    bam_path_dna="/path/to/dna/bam",
+    bam_path_rna="/path/to/rna/bam"
+)
+sample_1 = PairedSample(
+    id="sample_1",
+    snv_vcf_paths=["/where/my/mutect/vcfs/live",
+                   "/where/my/strelka/vcfs/live"]
+    indel_vcfs_paths=[...],
+    tumor_sample=sample_1_tumor
     ...
-
+)
+patient_1 = Patient(
+    id="patient_1",
+    ...
+    paired_samples=[sample_1]
+)
 cohort = Cohort(
     ...
-    benefit_col="patient_durable_benefit",
-    snv_file_format_funcs=[
-        mutect_snv_file_format_func,
-        strelka_snv_file_format_func
-    ]
+    patients=[patient_1]
 )
 
 # Comparison plot of missense mutation counts between benefit and no-benefit patients
 cohort.plot_benefit(on=missense_snv_count)
 
 # Raw missense mutations counts
-missense_snv_col, updated_dataframe = missense_snv_count(cohort)
+missense_snv_col, dataframe = missense_snv_count(cohort)
 ```

--- a/README.md
+++ b/README.md
@@ -49,18 +49,14 @@ sample_1_tumor = Sample(
     bam_path_dna="/path/to/dna/bam",
     bam_path_rna="/path/to/rna/bam"
 )
-sample_1 = PairedSample(
-    id="sample_1",
-    snv_vcf_paths=["/where/my/mutect/vcfs/live",
-                   "/where/my/strelka/vcfs/live"]
-    indel_vcfs_paths=[...],
-    tumor_sample=sample_1_tumor
-    ...
-)
 patient_1 = Patient(
     id="patient_1",
     ...
-    paired_samples=[sample_1]
+    snv_vcf_paths=["/where/my/mutect/vcfs/live",
+                   "/where/my/strelka/vcfs/live"]
+    indel_vcfs_paths=[...],
+    tumor_sample=sample_1_tumor,
+    ...
 )
 cohort = Cohort(
     ...

--- a/cohorts/collection.py
+++ b/cohorts/collection.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2016. Mount Sinai School of Medicine
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+class Collection(object):
+    def __init__(self, elements):
+        self.elements = elements
+
+    def short_string(self):
+        """
+        Compact string representation which doesn't print any of the
+        collection elements.
+        """
+        file_str = ""
+        if self.filename:
+            file_str = " from '%s'" % self.filename
+        return "<%s%s with %d elements>" % (
+            self.__class__.__name__,
+            file_str,
+            len(self))
+
+    def to_string(self, limit=None):
+        """
+        Create a string representation of this collection, showing up to
+        `limit` items.
+        """
+        header = self.short_string()
+        if len(self) == 0:
+            return header
+        contents = ""
+        element_lines = [
+            "  -- %s" % (element,)
+            for element in self.elements[:limit]
+        ]
+        contents = "\n".join(element_lines)
+
+        if limit is not None and len(self.elements) > limit:
+            contents += "\n  ... and %d more" % (len(self) - limit)
+        return "%s\n%s" % (header, contents)
+
+    def __str__(self):
+        return self.to_string(limit=50)
+
+    def __repr__(self):
+        return str(self)
+
+    def __len__(self):
+        return len(self.elements)
+
+    def __iter__(self):
+        return iter(self.elements)
+
+    def __getitem__(self, idx):
+        return self.elements[idx]

--- a/cohorts/collection.py
+++ b/cohorts/collection.py
@@ -22,11 +22,8 @@ class Collection(object):
         collection elements.
         """
         file_str = ""
-        if self.filename:
-            file_str = " from '%s'" % self.filename
-        return "<%s%s with %d elements>" % (
+        return "<%s with %d elements>" % (
             self.__class__.__name__,
-            file_str,
             len(self))
 
     def to_string(self, limit=None):

--- a/cohorts/count.py
+++ b/cohorts/count.py
@@ -20,55 +20,49 @@ import pandas as pd
 from varcode import EffectCollection
 from varcode.effects import Substitution
 
-from .load import verify_group_by
-
 def snv_count(cohort, **kwargs):
-    sample_variants = cohort.load_variants(**kwargs)
-    def count_func(sample):
-        if sample in sample_variants:
-            return len(sample_variants[sample])
+    patient_variants = cohort.load_variants(**kwargs)
+    def count_func(patient_id):
+        if patient_id in patient_variants:
+            return len(patient_variants[patient_id])
         return np.nan
     return count(cohort, count_func, count_col="snv_count")
 
 def nonsynonymous_snv_count(cohort, **kwargs):
-    sample_nonsynonymous_effects = cohort.load_effects(only_nonsynonymous=True, **kwargs)
-    def count_func(sample):
-        if sample in sample_nonsynonymous_effects:
-            return len(sample_nonsynonymous_effects[sample])
+    patient_nonsynonymous_effects = cohort.load_effects(only_nonsynonymous=True, **kwargs)
+    def count_func(patient_id):
+        if patient_id in patient_nonsynonymous_effects:
+            return len(patient_nonsynonymous_effects[patient_id])
         return np.nan
     return count(cohort, count_func, count_col="nonsynonymous_snv_count")
 
 def missense_snv_count(cohort, **kwargs):
-    sample_nonsynonymous_effects = cohort.load_effects(only_nonsynonymous=True, **kwargs)
-    sample_missense_effects = dict(
-        [(sample,
+    patient_nonsynonymous_effects = cohort.load_effects(only_nonsynonymous=True, **kwargs)
+    patient_missense_effects = dict(
+        [(patient_id,
           EffectCollection(
               [effect for effect in effects if type(effect) == Substitution]))
-         for (sample, effects) in sample_nonsynonymous_effects.items()])
-    def count_func(sample):
-        if sample in sample_missense_effects:
-            return len(sample_missense_effects[sample])
+         for (patient_id, effects) in patient_nonsynonymous_effects.items()])
+    def count_func(patient_id):
+        if patient_id in patient_missense_effects:
+            return len(patient_missense_effects[patient_id])
         return np.nan
     return count(cohort, count_func, count_col="missense_snv_count")
 
 def neoantigen_count(cohort, **kwargs):
-    sample_neoantigens = cohort.load_neoantigens(**kwargs)
-    def count_func(sample):
-        if sample in sample_neoantigens["sample_id"].unique():
-            return len(sample_neoantigens[sample_neoantigens["sample_id"] == sample])
+    patient_neoantigens = cohort.load_neoantigens(**kwargs)
+    def count_func(patient_id):
+        if patient_id in patient_neoantigens["patient_id"].unique():
+            return len(patient_neoantigens[patient_neoantigens["patient_id"] == patient_id])
         return np.nan
     return count(cohort, count_func, count_col="neoantigen_count")
 
-def count(cohort, count_func, count_col, group_by="patient"):
-    verify_group_by(group_by)
-
-    id_col = "patient_id" if group_by == "patient" else "sample_id"
-
-    df = cohort.as_dataframe(group_by=group_by)
-    df[count_col] = df[id_col].map(count_func)
+def count(cohort, count_func, count_col):
+    df = cohort.as_dataframe()
+    df[count_col] = df["patient_id"].map(count_func)
     original_len = len(df)
     df = df[~df[count_col].isnull()]
     updated_len = len(df)
     if updated_len < original_len:
-        print("Missing count for %d samples: from %d to %d" % (original_len - updated_len, original_len, updated_len))
+        print("Missing count for %d patients: from %d to %d" % (original_len - updated_len, original_len, updated_len))
     return count_col, df

--- a/cohorts/count.py
+++ b/cohorts/count.py
@@ -57,9 +57,14 @@ def neoantigen_count(cohort, **kwargs):
         return np.nan
     return count(cohort, count_func, count_col="neoantigen_count")
 
-def count(cohort, count_func, count_col):
-    df = cohort.clinical_dataframe.copy()
-    df[count_col] = df[cohort.clinical_dataframe_id_col].map(count_func)
+def count(cohort, count_func, count_col, group_by="paired_sample"):
+    if group_by not in ["patient", "paired_sample"]:
+        raise ValueError("Invalid group_by: %s" % group_by)
+
+    id_col = "patient_id" if group_by == "patient" else "sample_id"
+
+    df = cohort.as_dataframe(group_by=group_by).copy()
+    df[count_col] = df[id_col].map(count_func)
     original_len = len(df)
     df = df[~df[count_col].isnull()]
     updated_len = len(df)

--- a/cohorts/count.py
+++ b/cohorts/count.py
@@ -20,6 +20,8 @@ import pandas as pd
 from varcode import EffectCollection
 from varcode.effects import Substitution
 
+from .load import verify_group_by
+
 def snv_count(cohort, **kwargs):
     sample_variants = cohort.load_variants(**kwargs)
     def count_func(sample):
@@ -57,13 +59,12 @@ def neoantigen_count(cohort, **kwargs):
         return np.nan
     return count(cohort, count_func, count_col="neoantigen_count")
 
-def count(cohort, count_func, count_col, group_by="paired_sample"):
-    if group_by not in ["patient", "paired_sample"]:
-        raise ValueError("Invalid group_by: %s" % group_by)
+def count(cohort, count_func, count_col, group_by="patient"):
+    verify_group_by(group_by)
 
     id_col = "patient_id" if group_by == "patient" else "sample_id"
 
-    df = cohort.as_dataframe(group_by=group_by).copy()
+    df = cohort.as_dataframe(group_by=group_by)
     df[count_col] = df[id_col].map(count_func)
     original_len = len(df)
     df = df[~df[count_col].isnull()]

--- a/cohorts/load.py
+++ b/cohorts/load.py
@@ -280,15 +280,11 @@ class Cohort(Collection):
         df = pd.DataFrame()
         join_dataframes = []
 
-        if not join_with:
-            current_join_with = self.join_with
-        elif type(join_with) == list:
-            current_join_with = join_with
-        else:
-            current_join_with = [join_with]
+        current_join_with = first_not_none([join_with, self.join_with], [])
+        if type(current_join_with) == str:
+            current_join_with = [current_join_with]
 
-        current_join_how = self.join_how if join_how is None else join_how
-        current_join_how = "outer" if current_join_how is None else current_join_how
+        current_join_how = first_not_none([join_how, self.join_how], "outer")
 
         for dataframe in self.joinable_dataframes:
             if dataframe.name in current_join_with:
@@ -737,3 +733,9 @@ def col_func(cohort, on, col, col_equals):
 def verify_group_by(group_by):
     if group_by not in ["patient", "paired_sample"]:
         raise ValueError("Invalid group_by: %s" % group_by)
+
+def first_not_none(params, default):
+    for param in params:
+        if param is not None:
+            return param
+    return default

--- a/cohorts/load.py
+++ b/cohorts/load.py
@@ -262,8 +262,6 @@ class Cohort(Collection):
                              str(bad_caches))
 
     def as_dataframe(self, join_with=None, join_how=None):
-        join_dataframes = []
-
         # Use join_with if specified, otherwise fall back to what is defined in the class
         join_with = first_not_none_param([join_with, self.join_with], default=[])
         if type(join_with) == str:
@@ -361,7 +359,8 @@ class Cohort(Collection):
             failed_io = True
 
         if len(combined_variants) == 0 or failed_io:
-            raise ValueError("Variants did not exist for patient %s" % patient.id)
+            print("Variants did not exist for patient %s" % patient.id)
+            return VariantCollection([])
 
         if len(combined_variants) == 1:
             # There is nothing to merge
@@ -525,7 +524,8 @@ class Cohort(Collection):
             # MHC binding prediction
             epitopes = mhc_model.predict(isovar_rows_to_protein_sequences)
 
-            # Only include peptides that overlap a variant; without this filter, when we use
+            # Call `get_filtered_isovar_epitopes` in order to only include peptides that
+            # overlap a variant; without this filter, when we use
             # protein_sequence_length above, some 8mers generated from a 21mer source will
             # not overlap a variant.
             df_epitopes = self.get_filtered_isovar_epitopes(

--- a/cohorts/load.py
+++ b/cohorts/load.py
@@ -26,7 +26,7 @@ from types import FunctionType
 from collections import defaultdict
 
 import varcode
-from varcode import VariantCollection, EffectCollection, Collection
+from varcode import VariantCollection, EffectCollection
 from mhctools import NetMHCcons, EpitopeCollection
 from topiary import predict_epitopes_from_variants, epitopes_to_dataframe
 from topiary.sequence_helpers import contains_mutant_residues
@@ -35,6 +35,7 @@ from pysam import AlignmentFile
 
 from .survival import plot_kmf
 from .plot import mann_whitney_plot, fishers_exact_plot
+from .collection import Collection
 
 class InvalidDataError(ValueError):
     pass
@@ -172,10 +173,7 @@ class Cohort(Collection):
                  extra_dataframes=[]):
         Collection.__init__(
             self,
-            elements=patients,
-            path=None,
-            distinct=False,
-            sort_key=None)
+            elements=patients)
         self.cache_dir = cache_dir
         self.cache_results = cache_results
         self.extra_dataframes = extra_dataframes

--- a/cohorts/plot.py
+++ b/cohorts/plot.py
@@ -66,7 +66,8 @@ def fishers_exact_plot(data, condition1, condition2):
     return (oddsratio, pvalue, plot)
 
 def mann_whitney_plot(data, condition, distribution,
-                      condition_value=None, alternative="two-sided"):
+                      condition_value=None, alternative="two-sided",
+                      skip_plot=False):
     """
     Create a box plot comparing a condition and perform a
     Mann Whitney test to compare the distribution in condition A v B
@@ -88,13 +89,17 @@ def mann_whitney_plot(data, condition, distribution,
     alternative:
         Specify the sidedness of the Mann-Whitney test: "two-sided", "less"
         or "greater"
-    """
 
-    plot = stripboxplot(
-        x=condition,
-        y=distribution,
-        data=data
-    )
+    skip_plot:
+        Calculate the test statistic and p-value, but don't plot.
+    """
+    plot = None
+    if not skip_plot:
+        plot = stripboxplot(
+            x=condition,
+            y=distribution,
+            data=data
+        )
 
     if condition_value:
         condition_mask = data[condition] == condition_value

--- a/cohorts/plot.py
+++ b/cohorts/plot.py
@@ -28,7 +28,7 @@ def stripboxplot(x, y, data, **kwargs):
         data=data
     )
 
-    sb.stripplot(
+    return sb.stripplot(
         x=x,
         y=y,
         data=data,
@@ -53,7 +53,7 @@ def fishers_exact_plot(data, condition1, condition2):
     condition2: str
         Second binary column to compare
     """
-    sb.factorplot(
+    plot = sb.factorplot(
         x=condition1,
         y=condition2,
         kind='bar',
@@ -63,7 +63,7 @@ def fishers_exact_plot(data, condition1, condition2):
     print(count_table)
     oddsratio, pvalue = fisher_exact(count_table)
     print("Fisher's Exact Test: OR: {}, p-value={}".format(oddsratio, pvalue))
-    return (oddsratio, pvalue)
+    return (oddsratio, pvalue, plot)
 
 def mann_whitney_plot(data, condition, distribution, condition_value=None):
     """
@@ -85,7 +85,7 @@ def mann_whitney_plot(data, condition, distribution, condition_value=None):
         If `condition` is not a binary column, split on =/!= to condition_value
     """
 
-    stripboxplot(
+    plot = stripboxplot(
         x=condition,
         y=distribution,
         data=data
@@ -101,4 +101,4 @@ def mann_whitney_plot(data, condition, distribution, condition_value=None):
     )
 
     print("Mann-Whitney test: U={}, p-value={}".format(U, pvalue))
-    return (U, pvalue)
+    return (U, pvalue, plot)

--- a/cohorts/plot.py
+++ b/cohorts/plot.py
@@ -65,7 +65,8 @@ def fishers_exact_plot(data, condition1, condition2):
     print("Fisher's Exact Test: OR: {}, p-value={}".format(oddsratio, pvalue))
     return (oddsratio, pvalue, plot)
 
-def mann_whitney_plot(data, condition, distribution, condition_value=None):
+def mann_whitney_plot(data, condition, distribution,
+                      condition_value=None, alternative="two-sided"):
     """
     Create a box plot comparing a condition and perform a
     Mann Whitney test to compare the distribution in condition A v B
@@ -83,6 +84,10 @@ def mann_whitney_plot(data, condition, distribution, condition_value=None):
 
     condition_value:
         If `condition` is not a binary column, split on =/!= to condition_value
+
+    alternative:
+        Specify the sidedness of the Mann-Whitney test: "two-sided", "less"
+        or "greater"
     """
 
     plot = stripboxplot(
@@ -98,6 +103,7 @@ def mann_whitney_plot(data, condition, distribution, condition_value=None):
     U, pvalue = mannwhitneyu(
         data[condition_mask][distribution],
         data[~condition_mask][distribution],
+        alternative=alternative
     )
 
     print("Mann-Whitney test: U={}, p-value={}".format(U, pvalue))

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ six>=1.10.0
 lifelines>=0.9.1.0
 nose>=1.3.3
 pylint>=1.4.4
+isovar>=0.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ six>=1.10.0
 lifelines>=0.9.1.0
 nose>=1.3.3
 pylint>=1.4.4
-isovar>=0.0.2
+git+git://github.com/hammerlab/isovar

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,10 @@ if __name__ == "__main__":
             "topiary>=0.0.15",
             "six>=1.10.0",
             "lifelines>=0.9.1.0",
-            "git+git://github.com/hammerlab/isovar"
+            "isovar>=0.0.2",
+        ],
+        dependency_links=[
+            "git+git://github.com/hammerlab/isovar",
         ],
         long_description=readme,
         packages=["cohorts"],

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,8 @@ if __name__ == "__main__":
             "scipy>=0.17.0",
             "topiary>=0.0.15",
             "six>=1.10.0",
-            "lifelines>=0.9.1.0"
+            "lifelines>=0.9.1.0",
+            "isovar>=0.0.2"
         ],
         long_description=readme,
         packages=["cohorts"],

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ if __name__ == "__main__":
             "topiary>=0.0.15",
             "six>=1.10.0",
             "lifelines>=0.9.1.0",
-            "isovar>=0.0.2"
+            "git+git://github.com/hammerlab/isovar"
         ],
         long_description=readme,
         packages=["cohorts"],

--- a/test/data_generate.py
+++ b/test/data_generate.py
@@ -18,7 +18,7 @@ import vcf
 from varcode import load_vcf_fast
 from os import path, makedirs
 
-def generate_vcfs(id_to_mutation_count, file_format_func, template_name):
+def generate_vcfs(id_to_mutation_count, file_format, template_name):
     """
     Generate cropped VCFs from a template, for each sample.
 
@@ -36,7 +36,7 @@ def generate_vcfs(id_to_mutation_count, file_format_func, template_name):
         template_path = data_path(template_name)
         vcf_reader = vcf.Reader(filename=template_path)
         file_path = generated_data_path(
-            path.join("vcfs", file_format_func(sample_id, None, None)))
+            path.join("vcfs", file_format % sample_id))
         file_dir = path.dirname(file_path)
         if not path.exists(file_dir):
             makedirs(file_dir)

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -20,7 +20,7 @@ from .data_generate import generate_vcfs
 from cohorts import Cohort
 from cohorts.load import InvalidDataError
 
-import pandas as pd 
+import pandas as pd
 from nose.tools import raises, eq_
 
 def make_simple_clinical_dataframe(

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -63,4 +63,4 @@ def test_progressed_vs_pfs():
 
 def test_simple_cohort():
     cohort = make_simple_cohort()
-    eq_(len(cohort.clinical_dataframe), 3)
+    eq_(len(cohort.as_dataframe()), 3)

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -17,7 +17,7 @@ from __future__ import print_function
 from . import data_path, generated_data_path, DATA_DIR
 from .data_generate import generate_vcfs
 
-from cohorts import Cohort
+from cohorts import Cohort, Patient
 from cohorts.load import InvalidDataError
 
 import pandas as pd
@@ -28,7 +28,7 @@ def make_simple_clinical_dataframe(
         pfs_list=None,
         deceased_list=None,
         progressed_or_deceased_list=None):
-    return pd.DataFrame({"id": [1, 4, 5],
+    return pd.DataFrame({"id": ["1", "4", "5"],
                          "OS": [100, 150, 120] if os_list is None else os_list,
                          "PFS": [50, 40, 120] if pfs_list is None else pfs_list,
                          "deceased": [True, False, False] if deceased_list is None else deceased_list,
@@ -36,16 +36,18 @@ def make_simple_clinical_dataframe(
 
 def make_simple_cohort(**kwargs):
     clinical_dataframe = make_simple_clinical_dataframe(**kwargs)
+    patients = []
+    for i, row in clinical_dataframe.iterrows():
+        patient = Patient(id=row["id"],
+                          os=row["OS"],
+                          pfs=row["PFS"],
+                          deceased=row["deceased"],
+                          progressed_or_deceased=row["progressed_or_deceased"])
+        patients.append(patient)
+
     return Cohort(
-        data_dir=DATA_DIR,
-        cache_dir=generated_data_path("cache"),
-        sample_ids=list(clinical_dataframe["id"]),
-        clinical_dataframe=clinical_dataframe,
-        clinical_dataframe_id_col="id",
-        os_col="OS",
-        pfs_col="PFS",
-        deceased_col="deceased",
-        progressed_or_deceased_col="progressed_or_deceased")
+        patients=patients,
+        cache_dir=generated_data_path("cache"))
 
 def test_pfs_equal_to_os():
     # Should not error

--- a/test/test_count.py
+++ b/test/test_count.py
@@ -17,7 +17,7 @@ from __future__ import print_function
 from . import data_path, generated_data_path, DATA_DIR
 from .data_generate import generate_vcfs
 
-from cohorts import Cohort, PairedSample
+from cohorts import Cohort
 from cohorts.count import *
 
 import pandas as pd
@@ -49,9 +49,7 @@ def make_cohort(file_formats):
             vcf_filename = (file_format % patient.id)
             vcf_path = path.join(vcf_dir, vcf_filename)
             vcf_paths.append(vcf_path)
-        patient.paired_samples = [PairedSample(
-            id=patient.id,
-            snv_vcf_paths=vcf_paths)]
+        patient.snv_vcf_paths = vcf_paths
     return vcf_dir, cohort
 
 def test_snv_counts():

--- a/test/test_count.py
+++ b/test/test_count.py
@@ -17,7 +17,7 @@ from __future__ import print_function
 from . import data_path, generated_data_path, DATA_DIR
 from .data_generate import generate_vcfs
 
-from cohorts import Cohort
+from cohorts import Cohort, PairedSample
 from cohorts.count import *
 
 import pandas as pd
@@ -25,74 +25,57 @@ from nose.tools import raises, eq_
 from os import path
 from shutil import rmtree
 
-from .test_basic import make_simple_clinical_dataframe
+from .test_basic import make_simple_cohort
 
-def file_format_func_1(sample_id, normal_bam_id, tumor_bam_id):
-    return "sample_format1_%d.vcf" % sample_id
+FILE_FORMAT_1 = "patient_format1_%s.vcf"
+FILE_FORMAT_2 = "patient_format2_%s.vcf"
+FILE_FORMAT_3 = "patient_format3_%s.vcf"
 
-def file_format_func_2(sample_id, normal_bam_id, tumor_bam_id):
-    return "sample_format2_%d.vcf" % sample_id
-
-def file_format_func_3(sample_id, normal_bam_id, tumor_bam_id):
-    return "sample_format3_%d.vcf" % sample_id
+def make_cohort(file_formats):
+    cohort = make_simple_cohort()
+    patient_ids = [patient.id for patient in cohort]
+    vcf_dir = generate_vcfs(id_to_mutation_count=dict(zip(patient_ids, [3, 3, 6])),
+                            file_format=FILE_FORMAT_1,
+                            template_name="vcf_template_1.vcf")
+    _ = generate_vcfs(id_to_mutation_count=dict(zip(patient_ids, [4, 1, 5])),
+                      file_format=FILE_FORMAT_2,
+                      template_name="vcf_template_1.vcf")
+    _ = generate_vcfs(id_to_mutation_count=dict(zip(patient_ids, [5, 2, 3])),
+                      file_format=FILE_FORMAT_3,
+                      template_name="vcf_template_2.vcf")
+    for patient in cohort:
+        vcf_paths = []
+        for file_format in file_formats:
+            vcf_filename = (file_format % patient.id)
+            vcf_path = path.join(vcf_dir, vcf_filename)
+            vcf_paths.append(vcf_path)
+        patient.paired_samples = [PairedSample(
+            id=patient.id,
+            snv_vcf_paths=vcf_paths)]
+    return vcf_dir, cohort
 
 def test_snv_counts():
     """
     Generate VCFs per-sample, and confirm that the counting functions work as expected.
     """
-    clinical_dataframe = make_simple_clinical_dataframe()
-    sample_ids = list(clinical_dataframe["id"])
     vcf_dir, cohort = None, None
     try:
-        vcf_dir = generate_vcfs(dict(zip(sample_ids, [4, 3, 6])),
-                                file_format_func_1, template_name="vcf_template_1.vcf")
-        cohort = Cohort(
-            data_dir=vcf_dir,
-            cache_dir=generated_data_path("cache"),
-            sample_ids=sample_ids,
-            clinical_dataframe=make_simple_clinical_dataframe(),
-            clinical_dataframe_id_col="id",
-            os_col="OS",
-            pfs_col="PFS",
-            deceased_col="deceased",
-            progressed_or_deceased_col="progressed_or_deceased",
-            snv_file_format_funcs=[file_format_func_1])
+        # Use all three VCF sources
+        vcf_dir, cohort = make_cohort([FILE_FORMAT_1])
 
         # The SNV count should be exactly what we generated
         count_col, df = snv_count(cohort)
         eq_(len(df), 3)
-        eq_(list(df[count_col]), [4, 3, 6])
+        eq_(list(df[count_col]), [3, 3, 6])
 
         count_col, df = missense_snv_count(cohort)
         eq_(len(df), 3)
-        eq_(list(df[count_col]), [3, 2, 4])
+        eq_(list(df[count_col]), [2, 2, 4])
     finally:
-        if path.exists(vcf_dir):
+        if vcf_dir is not None and path.exists(vcf_dir):
             rmtree(vcf_dir)
         if cohort is not None:
             cohort.clear_caches()
-
-def make_cohort(file_format_funcs):
-    clinical_dataframe = make_simple_clinical_dataframe()
-    sample_ids = list(clinical_dataframe["id"])
-    vcf_dir = generate_vcfs(dict(zip(sample_ids, [3, 3, 6])),
-                            file_format_func_1, template_name="vcf_template_1.vcf")
-    generate_vcfs(dict(zip(sample_ids, [4, 1, 5])),
-                  file_format_func_2, template_name="vcf_template_1.vcf")
-    generate_vcfs(dict(zip(sample_ids, [5, 2, 3])),
-                  file_format_func_3, template_name="vcf_template_2.vcf")
-
-    return (vcf_dir, Cohort(
-        data_dir=vcf_dir,
-        cache_dir=generated_data_path("cache"),
-        sample_ids=sample_ids,
-        clinical_dataframe=make_simple_clinical_dataframe(),
-        clinical_dataframe_id_col="id",
-        os_col="OS",
-        pfs_col="PFS",
-        deceased_col="deceased",
-        progressed_or_deceased_col="progressed_or_deceased",
-        snv_file_format_funcs=file_format_funcs))
 
 def test_merge_three():
     """
@@ -101,7 +84,7 @@ def test_merge_three():
     vcf_dir, cohort = None, None
     try:
         # Use all three VCF sources
-        vcf_dir, cohort = make_cohort([file_format_func_1, file_format_func_2, file_format_func_3])
+        vcf_dir, cohort = make_cohort([FILE_FORMAT_1, FILE_FORMAT_2, FILE_FORMAT_3])
 
         # [3, 3, 6] and [4, 1, 5] use the same template, resulting in a union of [4, 3, 6] unique variants
         # [5, 2, 3] uses a separate template, resulting in a union of [4, 3, 6] + [5, 2, 3] = [9, 5, 9] unique variants
@@ -113,7 +96,7 @@ def test_merge_three():
         count_col, df = snv_count(cohort, merge_type="intersection")
         eq_(list(df[count_col]), [0, 0, 0])
     finally:
-        if path.exists(vcf_dir):
+        if vcf_dir is not None and path.exists(vcf_dir):
             rmtree(vcf_dir)
         if cohort is not None:
             cohort.clear_caches()
@@ -125,7 +108,7 @@ def test_merge_two():
     vcf_dir, cohort = None, None
     try:
         # Now, with only two VCF sources
-        vcf_dir, cohort = make_cohort([file_format_func_1, file_format_func_2])
+        vcf_dir, cohort = make_cohort([FILE_FORMAT_1, FILE_FORMAT_2])
 
         # [3, 3, 6] and [4, 1, 5] use the same template, resulting in a union of [4, 3, 6] unique variants
         count_col, df = snv_count(cohort)
@@ -137,7 +120,7 @@ def test_merge_two():
         eq_(len(df), 3)
         eq_(list(df[count_col]), [3, 1, 5])
     finally:
-        if path.exists(vcf_dir):
+        if vcf_dir is not None and path.exists(vcf_dir):
             rmtree(vcf_dir)
         if cohort is not None:
             cohort.clear_caches()

--- a/test/test_plot.py
+++ b/test/test_plot.py
@@ -22,12 +22,13 @@ from cohorts.plot import mann_whitney_plot
 def test_mann_whitney():
     data = pd.DataFrame({"distribution": range(1, 7),
                          "condition": [True, False] * 3})
-    U_default, p_default, _ = mann_whitney_plot(data, "condition", "distribution")
+    U_default, p_default, _ = mann_whitney_plot(data, "condition", "distribution",
+                                                skip_plot=True)
     U_two, p_two, _ = mann_whitney_plot(data, "condition", "distribution",
-                                        alternative="two-sided")
+                                        alternative="two-sided", skip_plot=True)
     U_less, p_less, _ = mann_whitney_plot(data, "condition", "distribution",
-                                          alternative="less")
+                                          alternative="less", skip_plot=True)
     U_greater, p_greater, _ = mann_whitney_plot(data, "condition", "distribution",
-                                                alternative="greater")
+                                                alternative="greater", skip_plot=True)
     eq_(p_default, p_two)
     ok_((p_default == p_less * 2) or (p_default == p_greater * 2))

--- a/test/test_plot.py
+++ b/test/test_plot.py
@@ -1,0 +1,33 @@
+# Copyright (c) 2016. Mount Sinai School of Medicine
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import pandas as pd
+from nose.tools import eq_, ok_
+
+from cohorts.plot import mann_whitney_plot
+
+def test_mann_whitney():
+    data = pd.DataFrame({"distribution": range(1, 7),
+                         "condition": [True, False] * 3})
+    U_default, p_default, _ = mann_whitney_plot(data, "condition", "distribution")
+    U_two, p_two, _ = mann_whitney_plot(data, "condition", "distribution",
+                                        alternative="two-sided")
+    U_less, p_less, _ = mann_whitney_plot(data, "condition", "distribution",
+                                          alternative="less")
+    U_greater, p_greater, _ = mann_whitney_plot(data, "condition", "distribution",
+                                                alternative="greater")
+    eq_(p_default, p_two)
+    ok_((p_default == p_less * 2) or (p_default == p_greater * 2))


### PR DESCRIPTION
Highlights:
- Instead of passing in a million arguments to a single `Cohort` object, split that out into `Patient`, `Sample`, etc. This also makes me less worried about the ordering of `sample_ids`, `tumor_bam_ids`, etc.; before, it would have been easier to accidentally re-order those lists IMO.
- Since a VCF path didn't make sense to be specified as a parameter of a `Sample` (where the `Sample` could be tumor or normal), I created `PairedSample`.
- A `Cohort` is a `Collection` of `Patients`.
- Move away from passing path functions around. Paths are now passed in at the time of `Sample` or `PairedSample` creation.
- I added logic for sending extra dataframes to the `Cohort` for joining; that's the `join_with` (which dataframe to join) and `join_how` (how to join). Dataframes get stored in a `Cohort` and can be joined with the rest of the data on demand. For example: `cohort = data.init_cohort(join_with=["pdl1", "tcr"], join_how="inner")` or `cohort = data.init_cohort(join_with="cibersort")`.
- I tried, wherever I could, to make the logic work for situations where patient ID != paired sample ID != sample ID, though I don't yet have tests for this. It's not really my priority right now; I just got roped into it as a result of the new objects.
- Move cufflinks loading to cohorts.
- The `isovar` stuff hasn't changed since https://github.com/hammerlab/cohorts/pull/11.
- Add a mannwhitneyu test, and set two-sided to be the default.
- Plotting functions return the plot for further manipulation.
- Fixes https://github.com/hammerlab/cohorts/issues/1 by forcing and asserting string IDs.

I tried to keep the consumption part of the API (vs. loading in the data) mostly the same; things this breaks:
- `self.clinical_dataframe` is now `self.as_dataframe()`
- Anything that touches the `Cohort` object.

Also note that some of the `CohortDataFrame` and `group_by` logic is a bit confusing. I'd like to simplify it and better document it at some point, but would prefer to defer to another PR on that.
