### PR TITLE
Pass kwargs through to function

### DIFF
--- a/cohorts/load.py
+++ b/cohorts/load.py
@@ -675,6 +675,10 @@ class Cohort(Collection):
         - a function that takes a dataframe row as input and returns a boolean or quantity based on that row (with col being the name of that new boolean or quantity)
         - a string representing an existing column
         - a string representing a new column name, created by comparing column `col` with the value `col_equals`
+
+        If `on` is a function that creates a new column, pass extra keyword arguments
+        through to that function. If `on` is a string, pass extra keyword arguments
+        to the internal call to `as_dataframe`.
         """
         if type(on) == FunctionType:
             if col is None:

--- a/cohorts/load.py
+++ b/cohorts/load.py
@@ -678,7 +678,7 @@ class Cohort(Collection):
         """
         if type(on) == FunctionType:
             if col is None:
-                return on(self)
+                return on(self, **kwargs)
             return self.clinical_func(on, col)
         if type(on) == str:
             cohort_dataframe = self.as_dataframe(**kwargs)


### PR DESCRIPTION
Allow `on` functions with extra arguments.

The API can definitely be improved (`kwargs` are getting passed around haphazardly), but this is a quick fix for @e5c.
