### PR TITLE
Move polyphen data dump to Cohorts object

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,8 @@ varcode>=0.4.7
 pyensembl>=0.8.12
 six>=1.10.0
 lifelines>=0.9.1.0
+scikit-learn>=0.17.1
+vcf-annotate-polyphen>=0.1.2
 nose>=1.3.3
 pylint>=1.4.4
 git+git://github.com/hammerlab/isovar


### PR DESCRIPTION
So that we don't need to pass the polyphen path every time we call `load_polyphen_annotations`. This, in turn, means that user repos (e.g. bladder) can pass that directory through automatically without relevant notebooks ever needing to deal with that path.

Also snuck in a random/unrelated `load_dataframe` function, and an `as_dataframe` flag for `load_polyphen_annotations`. (Somewhat related to https://github.com/hammerlab/cohorts/issues/40.)

@armish 
