### PR TITLE
Allow extra keyword arguments in functions

### DIFF
--- a/cohorts/functions.py
+++ b/cohorts/functions.py
@@ -39,8 +39,8 @@ def nonsynonymous_snv_count(row, cohort, **kwargs):
 def missense_snv_count(row, cohort, **kwargs):
     patient_id = row["patient_id"]
     patient_missense_effects = cohort.load_effects(
-        only_nonsynonymous=True, 
-        patients=[cohort.patient_from_id(patient_id)], 
+        only_nonsynonymous=True,
+        patients=[cohort.patient_from_id(patient_id)],
         filter_fn=lambda effect, variant_metadata: type(effect) == Substitution,
         **kwargs)
     if patient_id in patient_missense_effects:

--- a/cohorts/load.py
+++ b/cohorts/load.py
@@ -350,6 +350,13 @@ class Cohort(Collection):
 
         if type(on) == FunctionType:
             return apply_func(on, col, df)
+
+        # For multiple functions, don't allow kwargs since we won't know which functions
+        # they apply to.
+        if len(kwargs) > 0:
+            raise ValueError("kwargs are not supported when collecting multiple functions "
+                             "as we don't know which function they apply to.")
+
         if type(on) == dict:
             cols = []
             for key, value in on.iteritems():


### PR DESCRIPTION
Allows arbitrary arguments in functions. Example:

```
def snv_count(row, hello, **kwargs):
    return hello

cohort.as_dataframe(snv_count, hello="new message")
```

@arahuja 
