### PR TITLE
Fix bugs with caching and NaN handling

### DIFF
--- a/cohorts/functions.py
+++ b/cohorts/functions.py
@@ -65,7 +65,7 @@ def neoantigen_count(row, cohort, qc_filter=False, **kwargs):
             variants = cohort.load_variants(patients = [patient])[patient.id]
             filter_mask = patient_neoantigens_df.apply(lambda row: neoantigen_qc_filter(row, variants.metadata), axis=1)
             patient_neoantigens_df = patient_neoantigens_df[filter_mask]
-        return len(patient_neoantigens)
+        return len(patient_neoantigens_df)
     return np.nan
 
 def expressed_neoantigen_count(row, cohort, **kwargs):

--- a/cohorts/functions.py
+++ b/cohorts/functions.py
@@ -47,7 +47,9 @@ def missense_snv_count(row, cohort, **kwargs):
 def neoantigen_count(row, cohort, **kwargs):
     patient_id = row["patient_id"]
     patient_neoantigens = cohort.load_neoantigens(patients=[cohort.patient_from_id(patient_id)], **kwargs)
-    return len(patient_neoantigens[patient_neoantigens["patient_id"] == patient_id])
+    if patient_id in patient_neoantigens:
+        return len(patient_neoantigens[patient_id])
+    return np.nan
 
 def expressed_neoantigen_count(row, cohort, **kwargs):
     return neoantigen_count(row, cohort, only_expressed=True)

--- a/cohorts/functions.py
+++ b/cohorts/functions.py
@@ -62,6 +62,7 @@ def neoantigen_count(row, cohort, qc_filter=False, **kwargs):
     if patient_id in patient_neoantigens:
         patient_neoantigens_df = patient_neoantigens[patient_id]
         if qc_filter:
+            variants = cohort.load_variants(patients = [patient])[patient.id]
             filter_mask = patient_neoantigens_df.apply(lambda row: neoantigen_qc_filter(row, variants.metadata), axis=1)
             patient_neoantigens_df = patient_neoantigens_df[filter_mask]
         return len(patient_neoantigens)

--- a/cohorts/load.py
+++ b/cohorts/load.py
@@ -743,7 +743,7 @@ class Cohort(Collection):
         if variants is None:
             return None
 
-        if hla_alleles in None:
+        if patient.hla_alleles is None:
             print("HLA alleles did not exist for patient %s" % patient.id)
             return None
 

--- a/cohorts/variant_filters.py
+++ b/cohorts/variant_filters.py
@@ -1,0 +1,53 @@
+# Copyright (c) 2016. Mount Sinai School of Medicine
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .variant_stats import variant_stats_from_variant
+
+import numpy as np
+from varcode import Substitution, Variant
+import re
+
+def variant_qc_filter(variant, variant_metadata):
+    somatic_stats = variant_stats_from_variant(variant, variant_metadata)
+
+    # Filter variant with depth < 30
+    if somatic_stats.tumor_stats.depth < 30 or somatic_stats.normal_stats.depth < 30:
+        return False
+
+    # Filter based on normal evidence
+    if somatic_stats.normal_stats.variant_allele_frequency > .02:
+        return False
+
+    if somatic_stats.tumor_stats.alt_depth < 5:
+        return False
+
+    return True
+
+def effect_qc_filter(effect, variant_metadata):
+    return variant_qc_filter(effect.variant, variant_metadata)
+
+def neoantigen_qc_filter(row, metadata):
+    variant = variant_string_to_variant(row["variant"])
+    return variant_qc_filter(variant, metadata[variant])
+
+# TODO: Remove this hack and properly store the objects themselves.
+genomic_coord_regex = r"g\.([0-9]+)([A|C|T|G])>([A|C|T|G])"
+def variant_string_to_variant(variant_str, reference="grch37"):
+    chrom, coord = variant_str.split()
+    m = re.match(genomic_coord_regex, coord)
+    start = m.group(1)
+    ref = m.group(2)
+    alt = m.group(3)
+    variant = Variant(contig=chrom, start=start, ref=ref, alt=alt, ensembl=reference)
+    return variant

--- a/test/data/empty-neoantigens.csv
+++ b/test/data/empty-neoantigens.csv
@@ -1,0 +1,1 @@
+allele,peptide,length,ic50,percentile_rank,gene,gene_id,transcript,transcript_id,variant,effect,effect_type,prediction_method,protein_length,protein_mutation_start,protein_mutation_end,peptide_start_in_protein,novel_epitope,contains_mutant_residues,occurs_in_self_ligandome,mutation_start_in_peptide,mutation_end_in_peptide,patient_id

--- a/test/test_missing.py
+++ b/test/test_missing.py
@@ -134,6 +134,8 @@ def generate_empty_neoantigens(cohort,
                 makedirs(path.dirname(neoantigen_path))
                 with open(neoantigen_path, "w") as f:
                     df_neoantigens = pd.read_csv(data_path("empty-neoantigens.csv"))
+                    # pylint: disable=no-member
+                    # pylint gets confused by to_csv
                     df_neoantigens.to_csv(neoantigen_path)
         else:
             raise ValueError("Patient ID needs to be empty or zero")

--- a/test/test_missing.py
+++ b/test/test_missing.py
@@ -20,6 +20,7 @@ from .data_generate import generate_vcfs
 from cohorts.functions import *
 from cohorts.load import filter_not_null
 
+import pandas as pd
 from nose.tools import raises, eq_, ok_
 from os import path, makedirs
 from shutil import rmtree
@@ -86,11 +87,6 @@ def test_missing_vcf_path():
         count_col, df = cohort.as_dataframe(missense_snv_count)
         eq_(len(df), 3)
         ok_(np.isnan(list(df[count_col])[0]))
-
-        generate_empty_neoantigens(cohort)
-
-        count_col, df = cohort.as_dataframe(neoantigen_count)
-        eq_(len(df), 3)
     finally:
         if vcf_dir is not None and path.exists(vcf_dir):
             rmtree(vcf_dir)
@@ -128,7 +124,7 @@ def generate_empty_neoantigens(cohort,
                                patient_ids_with_zero_neoantigens,
                                patient_ids_with_empty_neoantigens):
     for patient in cohort:
-        if patient.id in patient_ids_with_empty_patient_ids:
+        if patient.id in patient_ids_with_empty_neoantigens:
             continue
         elif patient.id in patient_ids_with_zero_neoantigens:
             neoantigen_path = generated_data_path(

--- a/test/test_missing.py
+++ b/test/test_missing.py
@@ -1,0 +1,143 @@
+# Copyright (c) 2016. Mount Sinai School of Medicine
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+from . import data_path, generated_data_path
+from .data_generate import generate_vcfs
+
+from cohorts.functions import *
+from cohorts.load import filter_not_null
+
+from nose.tools import raises, eq_, ok_
+from os import path, makedirs
+from shutil import rmtree
+
+from .test_basic import make_simple_cohort
+
+def make_missing_vcf_cohort(patient_ids_with_missing_paths, missing_paths):
+    file_format = "patient_format_%s.vcf"
+    cohort = make_simple_cohort()
+    patient_ids = [patient.id for patient in cohort]
+    vcf_dir = generate_vcfs(id_to_mutation_count=dict(zip(patient_ids, [3, 3, 6])),
+                            file_format=file_format,
+                            template_name="vcf_template_1.vcf")
+    for patient in cohort:
+        vcf_paths = []
+        vcf_filename = (file_format % patient.id)
+        vcf_path = path.join(vcf_dir, vcf_filename)
+        vcf_paths.append(vcf_path)
+        if patient.id in patient_ids_with_missing_paths:
+            patient.snv_vcf_paths = missing_paths
+        else:
+            patient.snv_vcf_paths = vcf_paths
+    return vcf_dir, cohort
+
+def test_broken_vcf_path():
+    """
+    Generate VCFs per-sample, and confirm that the NaNs are returned when
+    VCF paths are broken.
+    """
+    vcf_dir, cohort = None, None
+    try:
+        vcf_dir, cohort = make_missing_vcf_cohort(
+            patient_ids_with_missing_paths=["1"],
+            missing_paths=["nonexistant_path"])
+
+        count_col, df = cohort.as_dataframe(snv_count)
+        eq_(len(df), 3)
+        ok_(np.isnan(list(df[count_col])[0]))
+
+        count_col, df = cohort.as_dataframe(missense_snv_count)
+        eq_(len(df), 3)
+        ok_(np.isnan(list(df[count_col])[0]))
+    finally:
+        if vcf_dir is not None and path.exists(vcf_dir):
+            rmtree(vcf_dir)
+        if cohort is not None:
+            cohort.clear_caches()
+
+def test_missing_vcf_path():
+    """
+    Generate VCFs per-sample, and confirm that the NaNs are returned when
+    VCF paths are broken.
+    """
+    vcf_dir, cohort = None, None
+    try:
+        vcf_dir, cohort = make_missing_vcf_cohort(
+            patient_ids_with_missing_paths=["1"],
+            missing_paths=[])
+
+        count_col, df = cohort.as_dataframe(snv_count)
+        eq_(len(df), 3)
+        ok_(np.isnan(list(df[count_col])[0]))
+
+        count_col, df = cohort.as_dataframe(missense_snv_count)
+        eq_(len(df), 3)
+        ok_(np.isnan(list(df[count_col])[0]))
+
+        generate_empty_neoantigens(cohort)
+
+        count_col, df = cohort.as_dataframe(neoantigen_count)
+        eq_(len(df), 3)
+    finally:
+        if vcf_dir is not None and path.exists(vcf_dir):
+            rmtree(vcf_dir)
+        if cohort is not None:
+            cohort.clear_caches()
+
+def test_no_neoantigens():
+    """
+    Make sure that exactly 0 neoantigens is treated differently than no calculated
+    neoantigens.
+    """
+    vcf_dir, cohort = None, None
+    try:
+        vcf_dir, cohort = make_missing_vcf_cohort(
+            patient_ids_with_missing_paths=["1"],
+            missing_paths=[])
+
+        generate_empty_neoantigens(cohort,
+                                   patient_ids_with_zero_neoantigens=["4", "5"],
+                                   patient_ids_with_empty_neoantigens=["1"])
+
+        count_col, df = cohort.as_dataframe(neoantigen_count)
+        eq_(len(df), 3)
+
+        # This is used internally by plotting functions.
+        # Ensure it filters NaN but not 0.
+        eq_(len(filter_not_null(df, count_col)), 2)
+    finally:
+        if vcf_dir is not None and path.exists(vcf_dir):
+            rmtree(vcf_dir)
+        if cohort is not None:
+            cohort.clear_caches()
+
+def generate_empty_neoantigens(cohort,
+                               patient_ids_with_zero_neoantigens,
+                               patient_ids_with_empty_neoantigens):
+    for patient in cohort:
+        if patient.id in patient_ids_with_empty_patient_ids:
+            continue
+        elif patient.id in patient_ids_with_zero_neoantigens:
+            neoantigen_path = generated_data_path(
+                path.join("cache", "cached-neoantigens",
+                          patient.id, "snv-union-neoantigens.csv"))
+            if not path.exists(path.dirname(neoantigen_path)):
+                makedirs(path.dirname(neoantigen_path))
+                with open(neoantigen_path, "w") as f:
+                    df_neoantigens = pd.read_csv(data_path("empty-neoantigens.csv"))
+                    df_neoantigens.to_csv(neoantigen_path)
+        else:
+            raise ValueError("Patient ID needs to be empty or zero")


### PR DESCRIPTION
In this PR:
- Fix #54 by returning neoantigens as a dictionary of dataframes, more in line with how `load_variants` works, to track the difference between 0 and not-calculated neoantigens.
- Fix #26 by making sure we don't cache "0 effects" that are based on not-calculated/empty variants.
- Add `filter_not_null` to a few plotting functions where it was missing.
- Test 0 vs. NaN neoantigens by faking neoantigens in the cache.

cc @arahuja 
