### PR TITLE
Add Pageant CoverageDepth output parsing

### DIFF
--- a/cohorts/load.py
+++ b/cohorts/load.py
@@ -41,7 +41,7 @@ from .survival import plot_kmf
 from .plot import mann_whitney_plot, fishers_exact_plot, roc_curve_plot
 from .collection import Collection
 from .varcode_utils import filter_variants_with_metadata, filter_effects_with_metadata
-import variant_filters
+from . import variant_filters
 
 class InvalidDataError(ValueError):
     pass

--- a/cohorts/variant_filters.py
+++ b/cohorts/variant_filters.py
@@ -57,6 +57,9 @@ def variant_string_to_variant(variant_str, reference="grch37"):
 def load_ensembl_coverage(cohort, coverage_path, min_depth=30):
     """
     Load in Pageant CoverageDepth results with Ensembl loci.
+
+    coverage_path is a path to Pageant CoverageDepth output directory, with
+    one subdirectory per patient and a `cdf.csv` file inside each patient subdir.
     """
     columns = [
         "NormalDepth",
@@ -80,7 +83,7 @@ def load_ensembl_coverage(cohort, coverage_path, min_depth=30):
             path.join(coverage_path, patient.id, "cdf.csv"),
             names=columns)
         # pylint: disable=no-member
-	    # pylint gets confused by read_csvpylint
+        # pylint gets confused by read_csv
         patient_ensembl_loci_df = patient_ensembl_loci_df[(
             (patient_ensembl_loci_df.NormalDepth == min_depth) &
             (patient_ensembl_loci_df.TumorDepth == min_depth))]

--- a/cohorts/variant_filters.py
+++ b/cohorts/variant_filters.py
@@ -79,6 +79,8 @@ def load_ensembl_coverage(cohort, coverage_path, min_depth=30):
         patient_ensembl_loci_df = pd.read_csv(
             path.join(coverage_path, patient.id, "cdf.csv"),
             names=columns)
+        # pylint: disable=no-member
+	    # pylint gets confused by read_csvpylint
         patient_ensembl_loci_df = patient_ensembl_loci_df[(
             (patient_ensembl_loci_df.NormalDepth == min_depth) &
             (patient_ensembl_loci_df.TumorDepth == min_depth))]


### PR DESCRIPTION
Mostly copied from https://github.com/hammerlab/checkpoint-trials/blob/master/analysis/lung-ipinivo-cohorts/ipinivo_cohorts.py#L44 (sorry for the private repo link)

Summary: incorporate ensembl coverage depth into a joinable DataFrame so we can say:

```
cohort = data.init_cohort(join_with="ensembl_coverage")
```

@arahuja 
