### PR TITLE
Updates to filtering

### DIFF
--- a/cohorts/load.py
+++ b/cohorts/load.py
@@ -552,9 +552,7 @@ class Cohort(Collection):
 
             merged_variants.metadata[variant] = dict(metadata)
 
-        # TODO: REMOVE THIS!
-        return VariantCollection(merged_variants[:10],
-                                 metadata=merged_variants.metadata)
+        return merged_variants
 
     def load_polyphen_annotations(self, as_dataframe=False):
         """Load a dataframe containing polyphen2 annotations for all variants

--- a/cohorts/varcode_utils.py
+++ b/cohorts/varcode_utils.py
@@ -51,3 +51,11 @@ def filter_neoantigens_with_metadata(neoantigens_df, variants, filter_fn):
         return neoantigens_df[filter_mask]
     else:
         return neoantigens_df
+
+def filter_polyphen_with_metadata(annotations_df, variants, filter_fn):
+    if filter_fn:
+        filter_mask = annotations_df.apply(
+            lambda row: filter_fn(row, variants), axis=1)
+        return annotations_df[filter_mask]
+    else:
+        return annotations_df

--- a/cohorts/varcode_utils.py
+++ b/cohorts/varcode_utils.py
@@ -43,3 +43,11 @@ def filter_effects_with_metadata(effect_collection, variant_collection_metadata,
                                   ])
     else:
         return effect_collection
+
+def filter_neoantigens_with_metadata(neoantigens_df, variants, filter_fn):
+    if filter_fn:
+        filter_mask = neoantigens_df.apply(
+            lambda row: filter_fn(row, variants), axis=1)
+        return neoantigens_df[filter_mask]
+    else:
+        return neoantigens_df

--- a/cohorts/variant_filters.py
+++ b/cohorts/variant_filters.py
@@ -39,20 +39,17 @@ def variant_qc_filter(variant, variant_metadata):
 def effect_qc_filter(effect, variant_metadata):
     return variant_qc_filter(effect.variant, variant_metadata)
 
-def neoantigen_qc_filter(row, metadata):
-    variant = variant_string_to_variant(row["variant"])
-    return variant_qc_filter(variant, metadata[variant])
-
-# TODO: Remove this hack and properly store the objects themselves.
-genomic_coord_regex = r"g\.([0-9]+)([A|C|T|G])>([A|C|T|G])"
-def variant_string_to_variant(variant_str, reference="grch37"):
-    chrom, coord = variant_str.split()
-    m = re.match(genomic_coord_regex, coord)
-    start = m.group(1)
-    ref = m.group(2)
-    alt = m.group(3)
-    variant = Variant(contig=chrom, start=start, ref=ref, alt=alt, ensembl=reference)
-    return variant
+def neoantigen_qc_filter(row, variants):
+    # We need to re-create the Variant object from the neoeantigen DataFrame.
+    # TODO: Just pickle the Neoantigen collection rather than dealing with
+    # DataFrames.
+    genome = variants[0].ensembl
+    variant = Variant(contig=row["chr"],
+                      ref=row["ref"],
+                      alt=row["alt"],
+                      start=row["start"],
+                      ensembl=genome)
+    return variant_qc_filter(variant, variants.metadata[variant])
 
 def load_ensembl_coverage(cohort, coverage_path, min_depth=30):
     """

--- a/cohorts/variant_filters.py
+++ b/cohorts/variant_filters.py
@@ -51,6 +51,15 @@ def neoantigen_qc_filter(row, variants):
                       ensembl=genome)
     return variant_qc_filter(variant, variants.metadata[variant])
 
+def polyphen_qc_filter(row, variants):
+    genome = variants[0].ensembl
+    variant = Variant(contig=row["chrom"],
+                      ref=row["ref"],
+                      alt=row["alt"],
+                      start=row["pos"],
+                      ensembl=genome)
+    return variant_qc_filter(variant, variants.metadata[variant])
+
 def load_ensembl_coverage(cohort, coverage_path, min_depth=30):
     """
     Load in Pageant CoverageDepth results with Ensembl loci.

--- a/cohorts/variant_stats.py
+++ b/cohorts/variant_stats.py
@@ -1,11 +1,11 @@
 from collections import namedtuple
 
 
-VariantStats = namedtuple("VariantStats", 
+VariantStats = namedtuple("VariantStats",
                           ["depth", "alt_depth", "variant_allele_frequency"])
 
 
-SomaticVariantStats = namedtuple("SomaticVariantStats", 
+SomaticVariantStats = namedtuple("SomaticVariantStats",
                           ["tumor_stats", "normal_stats"])
 
 
@@ -108,11 +108,11 @@ def _mutect_variant_stats(variant, sample_info):
     return VariantStats(depth=depth, alt_depth=alt_depth, variant_allele_frequency=vaf)
 
 
-def variant_stats_from_variant(variant, 
+def variant_stats_from_variant(variant,
                                metadata,
                                merge_fn=(lambda all_stats: \
                                 max(all_stats, key=(lambda stats: stats.tumor_stats.depth)))):
-    """Parse the variant calling stats from a variant called from multiple VCFs. The stats are merged 
+    """Parse the variant calling stats from a variant called from multiple VCFs. The stats are merged
     based on `merge_fn`
 
     Parameters
@@ -123,7 +123,7 @@ def variant_stats_from_variant(variant,
     merge_fn : function
         Function from list of SomaticVariantStats to single SomaticVariantStats.
         This is used if a variant is called by multiple callers or appears in multiple VCFs.
-        By default, this uses the data from the caller that had a higher tumor depth. 
+        By default, this uses the data from the caller that had a higher tumor depth.
 
     Returns
     -------

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 pandas>=0.15
 seaborn>=0.7.0
 scipy>=0.17.0
-topiary>=0.0.16
+topiary>=0.0.20
 mhctools>=0.2.3
 varcode>=0.4.12 
 pyensembl>=0.8.12

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ if __name__ == "__main__":
             "pandas>=0.15",
             "seaborn>=0.7.0",
             "scipy>=0.17.0",
-            "topiary>=0.0.16",
+            "topiary>=0.0.20",
             "mhctools>=0.2.3",
             "varcode>=0.4.12",
             "pyensembl>=0.8.12",

--- a/test/functions.py
+++ b/test/functions.py
@@ -24,17 +24,17 @@ from cohorts.functions import (
 # TODO: Tests should simply work with these options set to True.
 
 def snv_count(row, cohort, **kwargs):
-    return cohorts_snv_count(row, cohort, qc_filter=False,
+    return cohorts_snv_count(row, cohort, filter_fn=None,
                              normalized_per_mb=False, **kwargs)
 
 def missense_snv_count(row, cohort, **kwargs):
-    return cohorts_missense_snv_count(row, cohort, qc_filter=False,
+    return cohorts_missense_snv_count(row, cohort, filter_fn=None,
                                       normalized_per_mb=False, **kwargs)
 
 def neoantigen_count(row, cohort, **kwargs):
-    return cohorts_neoantigen_count(row, cohort, qc_filter=False,
+    return cohorts_neoantigen_count(row, cohort, filter_fn=None,
                                     normalized_per_mb=False, **kwargs)
 
 def expressed_neoantigen_count(row, cohort, **kwargs):
-    return cohorts_expressed_neoantigen_count(row, cohort, qc_filter=False,
+    return cohorts_expressed_neoantigen_count(row, cohort, filter_fn=None,
                                               normalized_per_mb=False, **kwargs)

--- a/test/functions.py
+++ b/test/functions.py
@@ -1,0 +1,40 @@
+# Copyright (c) 2016. Mount Sinai School of Medicine
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from cohorts.functions import (
+    snv_count as cohorts_snv_count,
+    missense_snv_count as cohorts_missense_snv_count,
+    neoantigen_count as cohorts_neoantigen_count,
+    expressed_neoantigen_count as cohorts_expressed_neoantigen_count
+)
+
+# Create functions that don't use QC filtering or exon MB normalization
+# because those aren't tested at the moment.
+# TODO: Tests should simply work with these options set to True.
+
+def snv_count(row, cohort, **kwargs):
+    return cohorts_snv_count(row, cohort, qc_filter=False,
+                             normalized_per_mb=False, **kwargs)
+
+def missense_snv_count(row, cohort, **kwargs):
+    return cohorts_missense_snv_count(row, cohort, qc_filter=False,
+                                      normalized_per_mb=False, **kwargs)
+
+def neoantigen_count(row, cohort, **kwargs):
+    return cohorts_neoantigen_count(row, cohort, qc_filter=False,
+                                    normalized_per_mb=False, **kwargs)
+
+def expressed_neoantigen_count(row, cohort, **kwargs):
+    return cohorts_expressed_neoantigen_count(row, cohort, qc_filter=False,
+                                              normalized_per_mb=False, **kwargs)

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -16,6 +16,7 @@ from __future__ import print_function
 
 from . import data_path, generated_data_path, DATA_DIR
 from .data_generate import generate_vcfs
+from .functions import *
 
 from cohorts import Cohort, Patient
 from cohorts.load import InvalidDataError

--- a/test/test_count.py
+++ b/test/test_count.py
@@ -116,7 +116,7 @@ def test_merge_two():
         eq_(len(df), 3)
         eq_(list(df[count_col]), [3, 1, 5])
 
-        cohort_variants = cohort.load_variants(merge_type="intersection")
+        cohort_variants = cohort.load_variants(merge_type="intersection", filter_fn=None)
         for (sample, variants) in cohort_variants.items():
             for variant in variants:
                 metadata = variants.metadata[variant]

--- a/test/test_count.py
+++ b/test/test_count.py
@@ -17,8 +17,7 @@ from __future__ import print_function
 from varcode import ExonicSpliceSite, Substitution
 
 from .data_generate import generate_vcfs
-
-from cohorts.functions import *
+from .functions import *
 
 from nose.tools import raises, eq_
 from os import path

--- a/test/test_missing.py
+++ b/test/test_missing.py
@@ -44,6 +44,7 @@ def make_missing_vcf_cohort(patient_ids_with_missing_paths, missing_paths):
             patient.snv_vcf_paths = missing_paths
         else:
             patient.snv_vcf_paths = vcf_paths
+        patient.hla_alleles = ["HLA-A02:01"]
     return vcf_dir, cohort
 
 def test_broken_vcf_path():

--- a/test/test_missing.py
+++ b/test/test_missing.py
@@ -16,11 +16,12 @@ from __future__ import print_function
 
 from . import data_path, generated_data_path
 from .data_generate import generate_vcfs
+from .functions import *
 
-from cohorts.functions import *
 from cohorts.load import filter_not_null
 
 import pandas as pd
+import numpy as np
 from nose.tools import raises, eq_, ok_
 from os import path, makedirs
 from shutil import rmtree

--- a/test/test_variant_stats.py
+++ b/test/test_variant_stats.py
@@ -65,7 +65,7 @@ def make_cohort(file_formats):
     return vcf_dir, cohort
 
 def extraction(cohort, extractor):
-    variants = cohort.load_variants()
+    variants = cohort.load_variants(filter_fn=None)
     for (sample, sample_variants) in variants.items():
         ok_(len(sample_variants) > 0)
         for variant in sample_variants:
@@ -137,7 +137,7 @@ def test_extract_and_merge_strelka_mutect_stats():
     try:
         # Use Mutect and Strelka VCF format with overlapping variants
         vcf_dir, cohort = make_cohort([FILE_FORMAT_2, FILE_FORMAT_4])
-        variants = cohort.load_variants()
+        variants = cohort.load_variants(filter_fn=None)
         patient_1_variants = variants['1']
 
         def test_stats(variant_index, expected_tumor_depth, expected_tumor_vaf):


### PR DESCRIPTION
In this PR:
- Add `normalized_per_mb` to all functions, defaulted to `True`.
- Change `qc_filter` in functions to `filter_fn` to be consistent with `load_*` functions.
- Make `filter_fn` in `load_*` (`load_variants`, `load_effects`, `load_neoantigens`) default to the appropriate filtering function.
- Updated required `topiary` version, as only recently does it include `chr`/`pos`/etc. in the output DataFrame, and we make use of that.
- Remove the regex string to variant hack, instead building a `Variant` object based on `chr`/`pos`/etc.
- Temporarily fix tests by having them not do filtering/normalization. (TODO later: both of these should be tested.)
- Add `filter_fn` to `load_polyphen*`.
- Update `min_mapping_quality` to `1`.

@arahuja 
