### PR TITLE
Filter to expressed variants

### DIFF
--- a/cohorts/functions.py
+++ b/cohorts/functions.py
@@ -86,10 +86,10 @@ def neoantigen_count(row, cohort, filter_fn=neoantigen_qc_filter,
     return np.nan
 
 def expressed_missense_snv_count(row, cohort, filter_fn=effect_qc_filter, **kwargs):
-    def expressed_filter_fn(filterable_effect, **kwargs):
+    def expressed_filter_fn(filterable_effect):
         if filter_fn is not None:
             return filter_fn(filterable_effect) and effect_expressed_filter(filterable_effect)
-        return filter_fn
+        return effect_expressed_filter(filterable_effect)
     return missense_snv_count(row, cohort, filter_fn=expressed_filter_fn, **kwargs)
 
 def expressed_neoantigen_count(row, cohort, **kwargs):

--- a/cohorts/functions.py
+++ b/cohorts/functions.py
@@ -14,8 +14,7 @@
 
 from __future__ import print_function
 
-from .variant_filters import (variant_qc_filter, effect_qc_filter, neoantigen_qc_filter,
-                              effect_expressed_filter)
+from .variant_filters import variant_qc_filter,effect_expressed_filter
 
 import numpy as np
 from varcode.effects import Substitution
@@ -35,7 +34,7 @@ def snv_count(row, cohort, filter_fn=variant_qc_filter,
         return count
     return np.nan
 
-def nonsynonymous_snv_count(row, cohort, filter_fn=effect_qc_filter,
+def nonsynonymous_snv_count(row, cohort, filter_fn=variant_qc_filter,
                             normalized_per_mb=True, **kwargs):
     patient_id = row["patient_id"]
     patient_nonsynonymous_effects = cohort.load_effects(
@@ -50,7 +49,7 @@ def nonsynonymous_snv_count(row, cohort, filter_fn=effect_qc_filter,
         return count
     return np.nan
 
-def missense_snv_count(row, cohort, filter_fn=effect_qc_filter,
+def missense_snv_count(row, cohort, filter_fn=variant_qc_filter,
                        normalized_per_mb=True, **kwargs):
     patient_id = row["patient_id"]
     def missense_filter_fn(filterable_effect):
@@ -70,7 +69,7 @@ def missense_snv_count(row, cohort, filter_fn=effect_qc_filter,
         return count
     return np.nan
 
-def neoantigen_count(row, cohort, filter_fn=neoantigen_qc_filter,
+def neoantigen_count(row, cohort, filter_fn=variant_qc_filter,
                      normalized_per_mb=True, **kwargs):
     patient_id = row["patient_id"]
     patient = cohort.patient_from_id(row["patient_id"])
@@ -85,7 +84,7 @@ def neoantigen_count(row, cohort, filter_fn=neoantigen_qc_filter,
         return count
     return np.nan
 
-def expressed_missense_snv_count(row, cohort, filter_fn=effect_qc_filter, **kwargs):
+def expressed_missense_snv_count(row, cohort, filter_fn=variant_qc_filter, **kwargs):
     def expressed_filter_fn(filterable_effect):
         if filter_fn is not None:
             return filter_fn(filterable_effect) and effect_expressed_filter(filterable_effect)

--- a/cohorts/functions.py
+++ b/cohorts/functions.py
@@ -14,7 +14,8 @@
 
 from __future__ import print_function
 
-from .variant_filters import variant_qc_filter, effect_qc_filter, neoantigen_qc_filter
+from .variant_filters import (variant_qc_filter, effect_qc_filter, neoantigen_qc_filter,
+                              effect_expressed_filter)
 
 import numpy as np
 from varcode.effects import Substitution
@@ -52,10 +53,11 @@ def nonsynonymous_snv_count(row, cohort, filter_fn=effect_qc_filter,
 def missense_snv_count(row, cohort, filter_fn=effect_qc_filter,
                        normalized_per_mb=True, **kwargs):
     patient_id = row["patient_id"]
-    def missense_filter_fn(effect, variant_metadata):
+    def missense_filter_fn(filterable_effect):
         if filter_fn is not None:
-            return type(effect) == Substitution and filter_fn(effect, variant_metadata)
-        return type(effect) == Substitution
+            return (type(filterable_effect.effect) == Substitution and
+                    filter_fn(filterable_effect))
+        return type(filterable_effect.effect) == Substitution
     patient_missense_effects = cohort.load_effects(
         only_nonsynonymous=True,
         patients=[cohort.patient_from_id(patient_id)],
@@ -83,8 +85,12 @@ def neoantigen_count(row, cohort, filter_fn=neoantigen_qc_filter,
         return count
     return np.nan
 
-def expressed_missense_snv_count(row, cohort, **kwargs):
-    return missense_snv_count(row, cohort, only_expressed=True, **kwargs)
+def expressed_missense_snv_count(row, cohort, filter_fn=effect_qc_filter, **kwargs):
+    def expressed_filter_fn(filterable_effect, **kwargs):
+        if filter_fn is not None:
+            return filter_fn(filterable_effect) and effect_expressed_filter(filterable_effect)
+        return filter_fn
+    return missense_snv_count(row, cohort, filter_fn=expressed_filter_fn, **kwargs)
 
 def expressed_neoantigen_count(row, cohort, **kwargs):
     return neoantigen_count(row, cohort, only_expressed=True, **kwargs)

--- a/cohorts/functions.py
+++ b/cohorts/functions.py
@@ -83,6 +83,9 @@ def neoantigen_count(row, cohort, filter_fn=neoantigen_qc_filter,
         return count
     return np.nan
 
+def expressed_missense_snv_count(row, cohort, **kwargs):
+    return missense_snv_count(row, cohort, only_expressed=True)
+
 def expressed_neoantigen_count(row, cohort, **kwargs):
     return neoantigen_count(row, cohort, only_expressed=True)
 

--- a/cohorts/functions.py
+++ b/cohorts/functions.py
@@ -84,10 +84,10 @@ def neoantigen_count(row, cohort, filter_fn=neoantigen_qc_filter,
     return np.nan
 
 def expressed_missense_snv_count(row, cohort, **kwargs):
-    return missense_snv_count(row, cohort, only_expressed=True)
+    return missense_snv_count(row, cohort, only_expressed=True, **kwargs)
 
 def expressed_neoantigen_count(row, cohort, **kwargs):
-    return neoantigen_count(row, cohort, only_expressed=True)
+    return neoantigen_count(row, cohort, only_expressed=True, **kwargs)
 
 @memoize
 def get_patient_to_mb(cohort):

--- a/cohorts/load.py
+++ b/cohorts/load.py
@@ -385,7 +385,7 @@ class Cohort(Collection):
         # they apply to.
         if len(kwargs) > 0:
             raise ValueError("kwargs are not supported when collecting multiple functions "
-                             "as we don"t know which function they apply to.")
+                             "as we don't know which function they apply to.")
 
         if type(on) == dict:
             cols = []
@@ -598,8 +598,6 @@ class Cohort(Collection):
         cache_name = self.cache_names["polyphen"]
         cached_file_name = "polyphen-annotations.csv"
         variants = self._load_single_patient_variants(patient,
-                                                      variant_type=self.variant_type,
-                                                      merge_type=self.merge_type,
                                                       filter_fn=None)
         if variants is None:
             return None

--- a/cohorts/load.py
+++ b/cohorts/load.py
@@ -384,7 +384,7 @@ class Cohort(Collection):
         if type(on) == FunctionType:
             return apply_func(on, col, df)
 
-        # For multiple functions, don't allow kwargs since we won"t know which functions
+        # For multiple functions, don't allow kwargs since we won't know which functions
         # they apply to.
         if len(kwargs) > 0:
             raise ValueError("kwargs are not supported when collecting multiple functions "

--- a/cohorts/load.py
+++ b/cohorts/load.py
@@ -42,8 +42,7 @@ from .plot import mann_whitney_plot, fishers_exact_plot, roc_curve_plot
 from .collection import Collection
 from .varcode_utils import (filter_variants, filter_effects,
                             filter_neoantigens, filter_polyphen)
-from .variant_filters import (variant_qc_filter, effect_qc_filter,
-                              neoantigen_qc_filter, polyphen_qc_filter)
+from .variant_filters import variant_qc_filter
 from . import variant_filters
 
 class InvalidDataError(ValueError):
@@ -492,7 +491,7 @@ class Cohort(Collection):
         patients : str, optional
             Filter to a subset of patients
         filter_fn : function
-            Takes a variant and it's metadata and returns a boolean. Only variants returning True are preserved. Defaults to `variant_qc_filter`.
+            Takes a FilterableVariant and returns a boolean. Only variants returning True are preserved. Defaults to `variant_qc_filter`.
 
         Returns
         -------
@@ -564,7 +563,7 @@ class Cohort(Collection):
         return merged_variants
 
     def load_polyphen_annotations(self, as_dataframe=False,
-                                  filter_fn=polyphen_qc_filter):
+                                  filter_fn=variant_qc_filter):
         """Load a dataframe containing polyphen2 annotations for all variants
 
         Parameters
@@ -573,9 +572,9 @@ class Cohort(Collection):
             Path to the WHESS/Polyphen2 SQLite database.
             Can be downloaded and bunzip2'ed from http://bit.ly/208mlIU
         filter_fn : function
-            Takes an annotation row and variants and returns a boolean.
+            Takes a FilterablePolyphen and returns a boolean.
             Only annotations returning True are preserved. Defaults to
-            `polyphen_qc_filter`.
+            `variant_qc_filter`.
 
         Returns
         -------
@@ -644,7 +643,7 @@ class Cohort(Collection):
                                filter_fn=filter_fn)
 
     def load_effects(self, patients=None, only_nonsynonymous=False,
-                     filter_fn=effect_qc_filter):
+                     filter_fn=variant_qc_filter):
         """Load a dictionary of patient_id to varcode.EffectCollection
         Parameters
         ----------
@@ -653,7 +652,7 @@ class Cohort(Collection):
         only_nonsynonymous : bool, optional
             If true, load only nonsynonymous effects, default False
         filter_fn : function
-            Takes an effect and it's variant's metadata and returns a boolean. Only effects returning True are preserved. Defaults to `effect_qc_filter`.
+            Takes a FilterableEffect and returns a boolean. Only effects returning True are preserved. Defaults to `variant_qc_filter`.
 
         Returns
         -------
@@ -745,7 +744,7 @@ class Cohort(Collection):
     def load_neoantigens(self, patients=None, only_expressed=False,
                          epitope_lengths=[8, 9, 10, 11], ic50_cutoff=500,
                          process_limit=10, max_file_records=None,
-                         filter_fn=neoantigen_qc_filter):
+                         filter_fn=variant_qc_filter):
         dfs = {}
         for patient in self.iter_patients(patients):
             df_epitopes = self._load_single_patient_neoantigens(

--- a/cohorts/load.py
+++ b/cohorts/load.py
@@ -777,7 +777,7 @@ class Cohort(Collection):
 
     def load_neoantigens(self, patients=None, variant_type="snv", merge_type="union",
                          only_expressed=False, epitope_lengths=[8, 9, 10, 11],
-                         ic50_cutoff=500, process_limit=30, max_file_records=None,
+                         ic50_cutoff=500, process_limit=10, max_file_records=None,
                          filter_fn=neoantigen_qc_filter):
         dfs = {}
         for patient in self.iter_patients(patients):

--- a/cohorts/load.py
+++ b/cohorts/load.py
@@ -21,7 +21,7 @@ import seaborn as sb
 import json
 import warnings
 
-# pylint doesn't like this line
+# pylint doesn"t like this line
 # pylint: disable=no-name-in-module
 import six.moves.cPickle as pickle
 from types import FunctionType
@@ -104,11 +104,11 @@ class Patient(object):
     indel_vcf_paths : list
         List of paths to indel VCFs for this patient; multple VCFs get merged.
     normal_sample : Sample
-        This patient's normal `Sample`.
+        This patient"s normal `Sample`.
     tumor_sample: Sample
-        This patient's tumor `Sample`.
+        This patient"s tumor `Sample`.
     hla_alleles : list
-        A list of this patient's HLA class I alleles.
+        A list of this patient"s HLA class I alleles.
     additional_data : dict
         A dictionary of additional data: name of datum mapping to value.
     """
@@ -151,7 +151,7 @@ class Patient(object):
         if self.progressed_or_deceased is None:
             self.progressed_or_deceased = self.progressed or self.deceased
 
-        # If we have both of these, ensure that they're in sync
+        # If we have both of these, ensure that they"re in sync
         if self.progressed_or_deceased is not None and self.progressed is not None:
             assert self.progressed_or_deceased == self.progressed or self.deceased, (
                     "progressed_or_deceased should equal progressed || deceased")
@@ -209,10 +209,10 @@ class Cohort(Collection):
     responder_pfs_equals_os : bool
         Ensure that the PFS values for responders (not progressed) are equal to
         OS values.
-    variant_type : {'snv', 'indel'}, optional
-        Load variants of a specific type, default 'snv'
-    merge_type : {'union', 'intersection'}, optional
-        Use this method to merge multiple variant sets for a single patient, default 'union'
+    variant_type : {"snv", "indel"}, optional
+        Load variants of a specific type, default "snv"
+    merge_type : {"union", "intersection"}, optional
+        Use this method to merge multiple variant sets for a single patient, default "union"
     """
     def __init__(self,
                  patients,
@@ -230,7 +230,7 @@ class Cohort(Collection):
         Collection.__init__(
             self,
             elements=patients)
-        # TODO: Patients shouldn't actually need to reference their cohorts; remove
+        # TODO: Patients shouldn"t actually need to reference their cohorts; remove
         # this when possible.
         for patient in patients:
             patient.cohort = self
@@ -300,7 +300,7 @@ class Cohort(Collection):
         patient_rows = []
         for patient in self:
             row = {} if patient.additional_data is None else patient.additional_data.copy()
-            row['patient_id'] = patient.id
+            row["patient_id"] = patient.id
             for clinical_col in ["benefit", "os", "pfs", "deceased",
                                 "progressed", "progressed_or_deceased"]:
                 row[clinical_col] = getattr(patient, clinical_col)
@@ -320,7 +320,7 @@ class Cohort(Collection):
                 df_loader.name,
                 old_len_df,
                 len(df)))
-        self.dataframe_hash = hash(str(df.sort_values('patient_id')))
+        self.dataframe_hash = hash(str(df.sort_values("patient_id")))
         return df
 
     def as_dataframe(self, on=None, col=None, join_with=None, join_how=None, **kwargs):
@@ -381,11 +381,11 @@ class Cohort(Collection):
         if type(on) == FunctionType:
             return apply_func(on, col, df)
 
-        # For multiple functions, don't allow kwargs since we won't know which functions
+        # For multiple functions, don"t allow kwargs since we won"t know which functions
         # they apply to.
         if len(kwargs) > 0:
             raise ValueError("kwargs are not supported when collecting multiple functions "
-                             "as we don't know which function they apply to.")
+                             "as we don"t know which function they apply to.")
 
         if type(on) == dict:
             cols = []
@@ -571,7 +571,7 @@ class Cohort(Collection):
         ----------
         database_file : string, sqlite
             Path to the WHESS/Polyphen2 SQLite database.
-            Can be downloaded and bunzip2'ed from http://bit.ly/208mlIU
+            Can be downloaded and bunzip2"ed from http://bit.ly/208mlIU
         filter_fn : function
             Takes a FilterablePolyphen and returns a boolean.
             Only annotations returning True are preserved. Defaults to
@@ -704,7 +704,7 @@ class Cohort(Collection):
         Parameters
         ----------
         filter_ok : bool, optional
-            If true, filter Cufflinks data to row with FPKM_status == 'OK'
+            If true, filter Cufflinks data to row with FPKM_status == "OK"
 
         Returns
         -------
@@ -726,12 +726,12 @@ class Cohort(Collection):
         ----------
         patient : Patient
         filter_ok : bool, optional
-            If true, filter Cufflinks data to row with FPKM_status == 'OK'
+            If true, filter Cufflinks data to row with FPKM_status == "OK"
 
         Returns
         -------
         cufflinks_data: Pandas dataframe
-            Pandas dataframe of sample's Cufflinks data
+            Pandas dataframe of sample"s Cufflinks data
             columns include patient_id, gene_id, gene_short_name, FPKM, FPKM_conf_lo, FPKM_conf_hi
         """
         data = pd.read_csv(patient.tumor_sample.cufflinks_path, sep="\t")
@@ -791,7 +791,7 @@ class Cohort(Collection):
             variants=variants,
             samfile=rna_bam_file,
             protein_sequence_length=protein_sequence_length,
-            min_reads_supporting_rna_sequence=3, # Per Alex R.'s suggestion
+            min_reads_supporting_rna_sequence=3, # Per Alex R."s suggestion
             min_transcript_prefix_length=MIN_TRANSCRIPT_PREFIX_LENGTH,
             max_transcript_mismatches=MAX_REFERENCE_TRANSCRIPT_MISMATCHES,
             max_protein_sequences_per_variant=1, # Otherwise we might have too much neoepitope diversity
@@ -847,7 +847,7 @@ class Cohort(Collection):
             # Store chr/pos/ref/alt in the cached DataFrame so we can filter based on
             # the variant later.
             for variant_column in ["chr", "pos", "ref", "alt"]:
-                # Be consistent with Topiary's output of "start" rather than "pos".
+                # Be consistent with Topiary"s output of "start" rather than "pos".
                 # Isovar, on the other hand, outputs "pos".
                 # See https://github.com/hammerlab/topiary/blob/5c12bab3d47bd86d396b079294aff141265f8b41/topiary/converters.py#L50
                 df_column = "start" if variant_column == "pos" else variant_column
@@ -878,8 +878,8 @@ class Cohort(Collection):
         Mostly replicates topiary.build_epitope_collection_from_binding_predictions
 
         Note: topiary needs to do fancy stuff like subsequence_protein_offset + binding_prediction.offset
-        in order to figure out whether a variant is in the peptide because it only has the variant's
-        offset into the full protein; but isovar gives us the variant's offset into the protein subsequence
+        in order to figure out whether a variant is in the peptide because it only has the variant"s
+        offset into the full protein; but isovar gives us the variant"s offset into the protein subsequence
         (dictated by protein_sequence_length); so all we need to do is map that onto the smaller 8-11mer
         peptides generated by mhctools.
         """
@@ -940,7 +940,7 @@ class Cohort(Collection):
         df = filter_not_null(df, "benefit")
         df = filter_not_null(df, plot_col)
         df.benefit = df.benefit.astype(bool)
-        return roc_curve_plot(df, plot_col, 'benefit', bootstrap_samples, ax=ax)
+        return roc_curve_plot(df, plot_col, "benefit", bootstrap_samples, ax=ax)
 
     def plot_benefit(self, on, col=None, benefit_col="benefit", ax=None,
                      mw_alternative="two-sided", **kwargs):
@@ -959,7 +959,7 @@ class Cohort(Collection):
         `on` or `col`.
 
         If the variable (through `on` or `col` is binary) this will compare
-        odds-ratios and perform a Fisher's exact test.
+        odds-ratios and perform a Fisher"s exact test.
 
         If the variable is numeric, this will compare the distributions through
         a Mann-Whitney test and plot the distributions with box-strip plot
@@ -1005,9 +1005,9 @@ class Cohort(Collection):
             See `cohort.load.as_dataframe`
         col : str, optional
             If specified, store the result of `on`. See `cohort.load.as_dataframe`
-        how : {'os', 'pfs'}, optional
+        how : {"os", "pfs"}, optional
             Whether to plot OS (overall survival) or PFS (progression free survival)
-        threshold : int or 'median', optional
+        threshold : int or "median", optional
             Threshold of `col` on which to split the cohort
         """
         assert how in ["os", "pfs"], "Invalid choice of survival plot type %s" % how
@@ -1025,7 +1025,6 @@ class Cohort(Collection):
             survival_col=how,
             threshold=threshold if threshold is not None else default_threshold,
             ax=ax)
-
         return results
 
     def plot_joint(self, on, on_two=None, **kwargs):
@@ -1055,32 +1054,34 @@ class Cohort(Collection):
         return(results)
 
     def summarize_provenance_per_cache(self):
-        """ Utility function to summarize provenance files for cached items used by a Cohort, for each cache_dir that exists.
-            Only existing cache_dirs are summarized. 
+        """Utility function to summarize provenance files for cached items used by a Cohort,
+        for each cache_dir that exists. Only existing cache_dirs are summarized.
 
-            This is a summary of provenance files because the function checks to see whether all patients data have 
-            the same provenance within the cache dir. The function assumes that it will be desireable to have all patients
-            data generated using the same environment, for each cache type.
+        This is a summary of provenance files because the function checks to see whether all
+        patients data have the same provenance within the cache dir. The function assumes
+        that it will be desireable to have all patients data generated using the same
+        environment, for each cache type.
 
-            At the moment, most PROVENANCE files contain details about packages used to generate the cached data file. However, this 
-            function is generic & so it summarizes the contents of those files irrespective of their contents.
-            
-            Returns
-            ----------
+        At the moment, most PROVENANCE files contain details about packages used to generat
+        e the cached data file. However, this function is generic & so it summarizes the
+        contents of those files irrespective of their contents.
 
-            Dict containing summarized provenance for each existing cache_dir, after checking to see that 
-            provenance files are identical among all patients in the data frame for that cache_dir.
+        Returns
+        ----------
+        Dict containing summarized provenance for each existing cache_dir, after checking
+        to see that provenance files are identical among all patients in the data frame for
+        that cache_dir.
 
-            If conflicting PROVENANCE files are discovered within a cache-dir:
-                - a warning is generated, describing the conflict
-                - and, a value of `None` is returned in the dictionary for that cache-dir
+        If conflicting PROVENANCE files are discovered within a cache-dir:
+         - a warning is generated, describing the conflict
+         - and, a value of `None` is returned in the dictionary for that cache-dir
 
-            See also
-            -----------
-            
-            * `?cohorts.Cohort.summarize_provenance` which summarizes provenance files among cache_dirs.
-            * `?cohorts.Cohort.summarize_dataframe` which hashes/summarizes contents of the data frame for this cohort
-
+        See also
+        -----------
+        * `?cohorts.Cohort.summarize_provenance` which summarizes provenance files among
+        cache_dirs.
+        * `?cohorts.Cohort.summarize_dataframe` which hashes/summarizes contents of the data
+        frame for this cohort.
         """
         provenance_summary = {}
         df = self.as_dataframe()
@@ -1106,36 +1107,36 @@ class Cohort(Collection):
                 else:
                     provenance_summary[cache_name] = None
         return(provenance_summary)
-    
+
     def summarize_dataframe(self):
-        """ Summarize default dataframe for this cohort using a hash function. 
-            Useful for confirming the version of data used in various reports, e.g. ipynbs
+        """Summarize default dataframe for this cohort using a hash function.
+        Useful for confirming the version of data used in various reports, e.g. ipynbs
         """
         if self.dataframe_hash:
             return(self.dataframe_hash)
         else:
             df = self._as_dataframe_unmodified()
             return(self.dataframe_hash)
-    
+
     def summarize_provenance(self):
-        """ Utility function to summarize provenance files for cached items used by a Cohort. 
+        """Utility function to summarize provenance files for cached items used by a Cohort.
 
-            At the moment, most PROVENANCE files contain details about packages used to generate files. However, this 
-            function is generic & so it summarizes the contents of those files irrespective of their contents.
-            
-            Returns
-            ----------
-            
-            Dict containing summary of provenance items, among all cache dirs used by the Cohort. 
+        At the moment, most PROVENANCE files contain details about packages used to
+        generate files. However, this function is generic & so it summarizes the contents
+        of those files irrespective of their contents.
 
-            IE if all provenances are identical across all cache dirs, then a single set of provenances is returned. 
-            Otherwise, if all provenances are not identical, the provenance items per cache_dir are returned.
+        Returns
+        ----------
+        Dict containing summary of provenance items, among all cache dirs used by the Cohort.
 
-            See also
-            ----------
-            
-            `?cohorts.Cohort.summarize_provenance_per_cache` which is used to summarize provenance for each existing cache_dir.
+        IE if all provenances are identical across all cache dirs, then a single set of
+        provenances is returned. Otherwise, if all provenances are not identical, the provenance
+        items per cache_dir are returned.
 
+        See also
+        ----------
+        `?cohorts.Cohort.summarize_provenance_per_cache` which is used to summarize provenance
+        for each existing cache_dir.
         """
         provenance_per_cache = self.summarize_provenance_per_cache()
         summary_provenance = None
@@ -1151,36 +1152,33 @@ class Cohort(Collection):
                 summary_provenance,
                 left_outer_diff = "In %s but not in %s" % (cache, summary_provenance_name),
                 right_outer_diff = "In %s but not in %s" % (summary_provenance_name, cache)
-                )
+            )
         ## compare provenance across cached items
         if num_discrepant == 0:
             prov = summary_provenance ## report summary provenance if exists
         else:
             prov = provenance_per_cache ## otherwise, return provenance per cache
         return(prov)
-    
+
     def summarize_data_sources(self):
-        """ Utility function to summarize data source status for this Cohort, useful for confirming
-            the state of data used for an analysis
+        """Utility function to summarize data source status for this Cohort, useful for confirming
+        the state of data used for an analysis
 
-            Returns
-            ----------
-            Dictionary with summary of data sources
+        Returns
+        ----------
+        Dictionary with summary of data sources
 
-            Currently contains
-
-            - dataframe_hash: hash of the dataframe (see `?cohorts.Cohort.summarize_dataframe`)
-            - provenance_file_summary: summary of provenance file contents (see `?cohorts.Cohort.summarize_provenance`)
+        Currently contains
+        - dataframe_hash: hash of the dataframe (see `?cohorts.Cohort.summarize_dataframe`)
+        - provenance_file_summary: summary of provenance file contents (see `?cohorts.Cohort.summarize_provenance`)
         """
         provenance_file_summary = self.summarize_provenance()
         dataframe_hash = self.summarize_dataframe()
         results = {
-            'provenance_file_summary': provenance_file_summary,
-            'dataframe_hash': dataframe_hash
-            }
+            "provenance_file_summary": provenance_file_summary,
+            "dataframe_hash": dataframe_hash
+        }
         return(results)
-        
-
 
 def first_not_none_param(params, default):
     """
@@ -1201,34 +1199,29 @@ def filter_not_null(df, col):
     return df
 
 def _provenance_str(provenance):
-    """ utility function used by compare_provenance to print diff
+    """Utility function used by compare_provenance to print diff
     """
     return ["%s==%s" % (key, value) for (key, value) in provenance]
-
 
 def compare_provenance(
         this_provenance, other_provenance,
         left_outer_diff = "In current but not comparison",
-        right_outer_diff = "In comparison but not current"
-        ):
-    """ utility function to compare two abritrary provenance dicts
-        returns number of discrepancies.
+        right_outer_diff = "In comparison but not current"):
+    """Utility function to compare two abritrary provenance dicts
+    returns number of discrepancies.
 
-        Parameters
-        ----------
+    Parameters
+    ----------
+    this_provenance: provenance dict (to be compared to "other_provenance")
+    other_provenance: comparison provenance dict
 
-        this_provenance: provenance dict (to be compared to "other_provenance")
-        other_provenance: comparison provenance dict
+    (optional)
+    left_outer_diff: description/prefix used when printing items in this_provenance but not in other_provenance
+    right_outer_diff: description/prefix used when printing items in other_provenance but not in this_provenance
 
-        (optional)
-        left_outer_diff: description/prefix used when printing items in this_provenance but not in other_provenance
-        right_outer_diff: description/prefix used when printing items in other_provenance but not in this_provenance
-
-        Returns
-        -----------
-
-        Number of discrepancies (0: None)
-
+    Returns
+    -----------
+    Number of discrepancies (0: None)
     """
     this_items = set(this_provenance.items())
     other_items = set(other_provenance.items())
@@ -1248,6 +1241,6 @@ def compare_provenance(
 
     if len(warn_str) > 0:
         warnings.warn(warn_str, Warning)
-    
+
     return(len(new_diff)+len(old_diff))
 

--- a/cohorts/load.py
+++ b/cohorts/load.py
@@ -554,8 +554,11 @@ class Cohort(Collection):
         # TODO: we're currently using the same isovar cache that we use for expressed
         # neoantigen prediction; so we pass in the same epitope lengths.
         # This is hacky and should be addressed.
-        df_isovar = self._load_single_patient_isovar(patient, variant_type, merge_type,
-                                                     epitope_lengths=[8, 9, 10, 11])
+        df_isovar = self._load_single_patient_isovar(patient=patient,
+                                                     variants=variants,
+                                                     epitope_lengths=[8, 9, 10, 11],
+                                                     variant_type=variant_type,
+                                                     merge_type=merge_type)
         for i, row in df_isovar.iterrows():
             genome = variants[0].ensembl
             variant = Variant(contig=row["chr"],
@@ -795,7 +798,8 @@ class Cohort(Collection):
                 dfs[patient.id] = df_epitopes
         return dfs
 
-    def _load_single_patient_isovar(self, patient, variant_type, merge_type, epitope_lengths):
+    def _load_single_patient_isovar(self, patient, variants, epitope_lengths,
+                                    variant_type, merge_type):
         # TODO: different epitope lengths, and other parameters, should result in
         # different caches
         isovar_cached_file_name = "%s-%s-isovar.csv" % (variant_type, merge_type)
@@ -862,9 +866,11 @@ class Cohort(Collection):
             process_limit=process_limit)
         if only_expressed:
             df_isovar = self._load_single_patient_isovar(patient=patient,
+                                                         variants=variants,
+                                                         epitope_lengths=epitope_lengths,
                                                          variant_type=variant_type,
-                                                         merge_type=merge_type,
-                                                         epitope_lengths=epitope_lengths)
+                                                         merge_type=merge_type)
+
             # Map from isovar rows to protein sequences
             isovar_rows_to_protein_sequences = dict([
                 (frozenset(row.to_dict().items()), row["amino_acids"]) for (i, row) in df_isovar.iterrows()])

--- a/cohorts/load.py
+++ b/cohorts/load.py
@@ -251,6 +251,8 @@ class Cohort(Collection):
         self.variant_type = variant_type
         self.merge_type = merge_type
 
+        assert variant_type in ["snv", "indel"], "Unknown variant type: %s" % variant_type
+
         self.verify_id_uniqueness()
         self.verify_survival()
         self.dataframe_hash = None
@@ -498,7 +500,6 @@ class Cohort(Collection):
         merged_variants
             Dictionary of patient_id to VariantCollection
         """
-        assert variant_type in ["snv", "indel"], "Unknown variant type: %s" % variant_type
         patient_variants = {}
 
         for patient in self.iter_patients(patients):
@@ -516,7 +517,7 @@ class Cohort(Collection):
                 return filter_variants(variant_collection=cached,
                                        patient=patient,
                                        filter_fn=filter_fn)
-            vcf_paths = patient.snv_vcf_paths if variant_type == "snv" else patient.indel_vcf_paths
+            vcf_paths = patient.snv_vcf_paths if self.variant_type == "snv" else patient.indel_vcf_paths
             variant_collections = [
                 (vcf_path, varcode.load_vcf_fast(vcf_path))
                 for vcf_path in vcf_paths
@@ -802,8 +803,7 @@ class Cohort(Collection):
                                          ic50_cutoff, process_limit, max_file_records,
                                          filter_fn):
         cached_file_name = "%s-%s-neoantigens.csv" % (self.variant_type, self.merge_type)
-        variants = self._load_single_patient_variants(
-            patient, only_expressed=False, filter_fn=None)
+        variants = self._load_single_patient_variants(patient, filter_fn=None)
         if variants is None:
             return None
 

--- a/cohorts/varcode_utils.py
+++ b/cohorts/varcode_utils.py
@@ -1,13 +1,68 @@
 from varcode import EffectCollection, VariantCollection
 
-def filter_variants_with_metadata(variant_collection, filter_fn):
+class FilterableVariant(object):
+    def __init__(self, variant, variant_collection, patient):
+        self.variant = variant
+        self.variant_collection = variant_collection
+        self.patient = patient
+
+    @property
+    def variant_metadata(self):
+        return self.variant_collection.metadata[self.variant]
+
+    @property
+    def genome(self):
+        return self.variant_collection[0].ensembl
+
+class FilterableEffect(FilterableVariant):
+    def __init__(self, effect, variant_collection, patient):
+        self.effect = effect
+        FilterableVariant.__init__(self,
+                                   variant=effect.variant,
+                                   variant_collection=variant_collection,
+                                   patient=patient)
+
+class FilterableNeoantigen(FilterableVariant):
+    def __init__(self, neoantigen_row, variant_collection, patient):
+        self.neoantigen_row = neoantigen_row
+        def build_variant(row, genome):
+            return Variant(
+                contig=row["chr"],
+                ref=row["ref"],
+                alt=row["alt"],
+                start=row["start"],
+                ensembl=genome)
+        variant = build_variant(neoantigen_row, self.genome)
+        FilterableVariant.__init__(self,
+                                   variant=variant,
+                                   variant_collection=variant_collection,
+                                   patient=patient)
+
+class FilterablePolyphenVariant(FilterableVariant):
+    def __init__(self, polyphen_row, variant_collection, patient):
+        self.polyphen_row = polyphen_row
+        def build_variant(row, genome):
+            return Variant(
+                contig=row["chrom"],
+                ref=row["ref"],
+                alt=row["alt"],
+                start=row["pos"],
+                ensembl=genome)
+        variant = build_variant(polyphen_row, self.genome)
+        FilterableVariant.__init__(self,
+                                   variant=variant,
+                                   variant_collection=variant_collection,
+                                   patient=patient)
+
+def filter_variants(variant_collection, patient, filter_fn):
     """Filter variants from the Variant Collection
 
     Parameters
     ----------
     variant_collection : varcode.VariantCollection
+    patient : cohorts.Patient
     filter_fn: function
-        Takes a variant and it's metadata and returns a boolean. Only variants returning True are preserved.
+        Takes a FilterableVariant and returns a boolean. Only variants returning True are preserved.
 
     Returns
     -------
@@ -15,22 +70,27 @@ def filter_variants_with_metadata(variant_collection, filter_fn):
         Filtered variant collection, with only the variants passing the filter
     """
     if filter_fn:
-        return VariantCollection([variant
-                                  for variant in variant_collection
-                                  if filter_fn(variant, variant_collection.metadata[variant])
-                                  ],
-                                 metadata=variant_collection.metadata)
+        return variant_collection.clone_with_new_elements([
+            variant
+            for variant in variant_collection
+            if filter_fn(FilterableVariant(
+                    variant=variant,
+                    variant_collection=variant_collection,
+                    patient=patient))
+        ])
     else:
         return variant_collection
 
-def filter_effects_with_metadata(effect_collection, variant_collection_metadata, filter_fn):
+def filter_effects(effect_collection, variant_collection, patient, filter_fn):
     """Filter variants from the Effect Collection
 
     Parameters
     ----------
     effect_collection : varcode.EffectCollection
+    variant_collection : varcode.VariantCollection
+    patient : cohorts.Patient
     filter_fn: function
-        Takes an effect and it's variant's metadata and returns a boolean. Only effects returning True are preserved.
+        Takes a FilterableEffect and returns a boolean. Only effects returning True are preserved.
 
     Returns
     -------
@@ -38,25 +98,34 @@ def filter_effects_with_metadata(effect_collection, variant_collection_metadata,
         Filtered effect collection, with only the variants passing the filter
     """
     if filter_fn:
-        return EffectCollection([effect
-                                  for effect in effect_collection
-                                  if filter_fn(effect, variant_collection_metadata[effect.variant])
-                                  ])
+        return EffectCollection([
+            effect
+            for effect in effect_collection
+            if filter_fn(FilterableEffect(
+                    effect=effect,
+                    variant_collection=variant_collection,
+                    patient=patient))])
     else:
         return effect_collection
 
-def filter_neoantigens_with_metadata(neoantigens_df, variants, filter_fn):
+def filter_neoantigens(neoantigens_df, variant_collection, patient, filter_fn):
     if filter_fn:
         filter_mask = neoantigens_df.apply(
-            lambda row: filter_fn(row, variants), axis=1)
+            lambda row: filter_fn(
+                FilterableNeoantigen(neoantigen_row=row,
+                                     variant_collection=variant_collection,
+                                     patient=patient)), axis=1)
         return neoantigens_df[filter_mask]
     else:
         return neoantigens_df
 
-def filter_polyphen_with_metadata(annotations_df, variants, filter_fn):
+def filter_polyphen(polyphen_df, variant_collection, patient, filter_fn):
     if filter_fn:
-        filter_mask = annotations_df.apply(
-            lambda row: filter_fn(row, variants), axis=1)
-        return annotations_df[filter_mask]
+        filter_mask = polyphen_df.apply(
+            lambda row: filter_fn(
+                FilterablePolyphen(polyphen_row=row,
+                                   variant_collection=variant_collection,
+                                   patient=patient)), axis=1)
+        return polyphen_df[filter_mask]
     else:
-        return annotations_df
+        return polyphen_df

--- a/cohorts/varcode_utils.py
+++ b/cohorts/varcode_utils.py
@@ -18,7 +18,8 @@ def filter_variants_with_metadata(variant_collection, filter_fn):
         return VariantCollection([variant
                                   for variant in variant_collection
                                   if filter_fn(variant, variant_collection.metadata[variant])
-                                  ])
+                                  ],
+                                 metadata=variant_collection.metadata)
     else:
         return variant_collection
 

--- a/cohorts/varcode_utils.py
+++ b/cohorts/varcode_utils.py
@@ -1,5 +1,8 @@
 from varcode import EffectCollection, VariantCollection, Variant
 
+def genome(variant_collection):
+    return variant_collection[0].ensembl
+
 class FilterableVariant(object):
     def __init__(self, variant, variant_collection, patient):
         self.variant = variant
@@ -12,7 +15,7 @@ class FilterableVariant(object):
 
     @property
     def genome(self):
-        return self.variant_collection[0].ensembl
+        return genome(self.variant_collection)
 
 class FilterableEffect(FilterableVariant):
     def __init__(self, effect, variant_collection, patient):
@@ -32,7 +35,7 @@ class FilterableNeoantigen(FilterableVariant):
                 alt=row["alt"],
                 start=row["start"],
                 ensembl=genome)
-        variant = build_variant(neoantigen_row, self.genome)
+        variant = build_variant(neoantigen_row, genome(variant_collection))
         FilterableVariant.__init__(self,
                                    variant=variant,
                                    variant_collection=variant_collection,
@@ -48,7 +51,7 @@ class FilterablePolyphen(FilterableVariant):
                 alt=row["alt"],
                 start=row["pos"],
                 ensembl=genome)
-        variant = build_variant(polyphen_row, self.genome)
+        variant = build_variant(polyphen_row, genome(variant_collection))
         FilterableVariant.__init__(self,
                                    variant=variant,
                                    variant_collection=variant_collection,

--- a/cohorts/varcode_utils.py
+++ b/cohorts/varcode_utils.py
@@ -1,4 +1,4 @@
-from varcode import EffectCollection, VariantCollection
+from varcode import EffectCollection, VariantCollection, Variant
 
 class FilterableVariant(object):
     def __init__(self, variant, variant_collection, patient):
@@ -38,7 +38,7 @@ class FilterableNeoantigen(FilterableVariant):
                                    variant_collection=variant_collection,
                                    patient=patient)
 
-class FilterablePolyphenVariant(FilterableVariant):
+class FilterablePolyphen(FilterableVariant):
     def __init__(self, polyphen_row, variant_collection, patient):
         self.polyphen_row = polyphen_row
         def build_variant(row, genome):

--- a/cohorts/variant_filters.py
+++ b/cohorts/variant_filters.py
@@ -53,15 +53,6 @@ def variant_qc_filter(filterable_variant,
 
     return True
 
-def effect_qc_filter(filterable_effect, **kwargs):
-    return variant_qc_filter(filterable_effect, **kwargs)
-
-def neoantigen_qc_filter(filterable_neoantigen, **kwargs):
-    return variant_qc_filter(filterable_neoantigen, **kwargs)
-
-def polyphen_qc_filter(filterable_polyphen, **kwargs):
-    return variant_qc_filter(filterable_polyphen, **kwargs)
-
 @memoize
 def expressed_variant_set(patient, variant_collection):
     # TODO: we're currently using the same isovar cache that we use for expressed

--- a/cohorts/variant_filters.py
+++ b/cohorts/variant_filters.py
@@ -20,24 +20,33 @@ import re
 import pandas as pd
 from os import path
 
-DEFAULT_DEPTH = 30
-DEFAULT_NORMAL_VAF = 0.02
-DEFAULT_ALT_DEPTH = 5
+DEFAULT_MIN_TUMOR_DEPTH = 30
+DEFAULT_MIN_NORMAL_DEPTH = 30
+DEFAULT_MIN_TUMOR_VAF = 0
+DEFAULT_MAX_NORMAL_VAF = 0.02
+DEFAULT_MIN_TUMOR_ALT_DEPTH = 5
 
-def variant_qc_filter(variant, variant_metadata, depth=DEFAULT_DEPTH,
-                      normal_vaf=DEFAULT_NORMAL_VAF, alt_depth=DEFAULT_ALT_DEPTH):
+def variant_qc_filter(variant, variant_metadata,
+                      min_tumor_depth=DEFAULT_MIN_TUMOR_DEPTH,
+                      min_normal_depth=DEFAULT_MIN_NORMAL_DEPTH,
+                      min_tumor_vaf=DEFAULT_MIN_TUMOR_VAF,
+                      max_normal_vaf=DEFAULT_MAX_NORMAL_VAF,
+                      min_tumor_alt_depth=DEFAULT_MIN_TUMOR_ALT_DEPTH):
     somatic_stats = variant_stats_from_variant(variant, variant_metadata)
 
     # Filter variant with depth < depth
-    if (somatic_stats.tumor_stats.depth < depth or
-        somatic_stats.normal_stats.depth < depth):
+    if (somatic_stats.tumor_stats.depth < min_tumor_depth or
+        somatic_stats.normal_stats.depth < min_normal_depth):
         return False
 
     # Filter based on normal evidence
-    if somatic_stats.normal_stats.variant_allele_frequency > normal_vaf:
+    if somatic_stats.normal_stats.variant_allele_frequency > max_normal_vaf:
         return False
 
-    if somatic_stats.tumor_stats.alt_depth < alt_depth:
+    if somatic_stats.tumor_stats.variant_allele_frequency < min_tumor_vaf:
+        return False
+
+    if somatic_stats.tumor_stats.alt_depth < min_tumor_alt_depth:
         return False
 
     return True

--- a/cohorts/variant_filters.py
+++ b/cohorts/variant_filters.py
@@ -28,7 +28,7 @@ def variant_qc_filter(variant, variant_metadata, depth=DEFAULT_DEPTH,
                       normal_vaf=DEFAULT_NORMAL_VAF, alt_depth=DEFAULT_ALT_DEPTH):
     somatic_stats = variant_stats_from_variant(variant, variant_metadata)
 
-    # Filter variant with depth < 30
+    # Filter variant with depth < depth
     if (somatic_stats.tumor_stats.depth < depth or
         somatic_stats.normal_stats.depth < depth):
         return False

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -36,7 +36,7 @@ def make_simple_clinical_dataframe(
                          "deceased": [True, False, False] if deceased_list is None else deceased_list,
                          "progressed_or_deceased": [True, True, False] if progressed_or_deceased_list is None else progressed_or_deceased_list})
 
-def make_simple_cohort(**kwargs):
+def make_simple_cohort(merge_type="union", **kwargs):
     clinical_dataframe = make_simple_clinical_dataframe(**kwargs)
     patients = []
     for i, row in clinical_dataframe.iterrows():
@@ -52,6 +52,7 @@ def make_simple_cohort(**kwargs):
     return Cohort(
         patients=patients,
         responder_pfs_equals_os=True,
+        merge_type=merge_type,
         cache_dir=generated_data_path("cache"))
 
 def test_pfs_equal_to_os():


### PR DESCRIPTION
In this PR:
- Factored some of the `df_isovar` logic out of `load_neoantigens` into a separate `_load_single_patient_isovar`, to use it outside the neoantigen context.
- Added `_filter_variants_to_expressed` to filter out any variant that isn't present in the `isovar` `DataFrame`.
- Randomly made it into this branch: parameterizing `variant_qc_filter`.

@arahuja 
