### PR TITLE
Fix effect counting

### DIFF
--- a/cohorts/functions.py
+++ b/cohorts/functions.py
@@ -43,7 +43,10 @@ def nonsynonymous_snv_count(row, cohort, filter_fn=None,
         filter_fn=filter_fn,
         **kwargs)
     if patient_id in patient_nonsynonymous_effects:
-        count = len(patient_nonsynonymous_effects[patient_id])
+        patient_variants = set()
+        for effect in patient_nonsynonymous_effects[patient_id]:
+            patient_variants.add(effect.variant)
+        count = len(patient_variants)
         if normalized_per_mb:
             count /= float(get_patient_to_mb(cohort)[patient_id])
         return count
@@ -63,7 +66,10 @@ def missense_snv_count(row, cohort, filter_fn=None,
         filter_fn=missense_filter_fn,
         **kwargs)
     if patient_id in patient_missense_effects:
-        count = len(patient_missense_effects[patient_id])
+        patient_variants = set()
+        for effect in patient_missense_effects[patient_id]:
+            patient_variants.add(effect.variant)
+        count = len(patient_variants)
         if normalized_per_mb:
             count /= float(get_patient_to_mb(cohort)[patient_id])
         return count

--- a/cohorts/load.py
+++ b/cohorts/load.py
@@ -504,7 +504,6 @@ class Cohort(Collection):
             Dictionary of patient_id to VariantCollection
         """
         patient_variants = {}
-
         for patient in self.iter_patients(patients):
             variants = self._load_single_patient_variants(patient, filter_fn)
             if variants is not None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ pylint>=1.4.4
 scikit-bio==0.4.2
 isovar==0.0.6
 patsy>=0.4.1
+mock>=2.0.0

--- a/test/functions.py
+++ b/test/functions.py
@@ -15,6 +15,7 @@
 from cohorts.functions import (
     snv_count as cohorts_snv_count,
     missense_snv_count as cohorts_missense_snv_count,
+    nonsynonymous_snv_count as cohorts_nonsynonymous_snv_count,
     neoantigen_count as cohorts_neoantigen_count,
     expressed_neoantigen_count as cohorts_expressed_neoantigen_count
 )
@@ -26,6 +27,10 @@ from cohorts.functions import (
 def snv_count(row, cohort, **kwargs):
     return cohorts_snv_count(row, cohort, filter_fn=None,
                              normalized_per_mb=False, **kwargs)
+
+def nonsynonymous_snv_count(row, cohort, **kwargs):
+    return cohorts_nonsynonymous_snv_count(row, cohort, filter_fn=None,
+                                           normalized_per_mb=False, **kwargs)
 
 def missense_snv_count(row, cohort, **kwargs):
     return cohorts_missense_snv_count(row, cohort, filter_fn=None,

--- a/test/test_count.py
+++ b/test/test_count.py
@@ -189,6 +189,11 @@ def test_multiple_effects():
     cohort = None
     try:
         cohort = make_simple_cohort(merge_type="snv")
+        """
+        <EffectCollection with 2 elements>
+        -- StopLoss(variant=chr1 g.46501738G>C, transcript_name=MAST2-001, transcript_id=ENST00000361297, effect_description=p.*1799Y (stop-loss))
+        -- StopLoss(variant=chr1 g.46501738G>C, transcript_name=MAST2-201, transcript_id=ENST00000372009, effect_description=p.*1609Y (stop-loss))
+        """
         variants = VariantCollection([Variant("1", 46501738, "G", "C", ensembl=75)])
         effects = variants.effects()
         effects_dict = {}

--- a/test/test_count.py
+++ b/test/test_count.py
@@ -189,11 +189,6 @@ def test_multiple_effects():
     cohort = None
     try:
         cohort = make_simple_cohort(merge_type="snv")
-        """
-        <EffectCollection with 2 elements>
-        -- StopLoss(variant=chr1 g.46501738G>C, transcript_name=MAST2-001, transcript_id=ENST00000361297, effect_description=p.*1799Y (stop-loss))
-        -- StopLoss(variant=chr1 g.46501738G>C, transcript_name=MAST2-201, transcript_id=ENST00000372009, effect_description=p.*1609Y (stop-loss))
-        """
         variants = VariantCollection([Variant("1", 46501738, "G", "C", ensembl=75)])
         effects = variants.effects()
         effects_dict = {}


### PR DESCRIPTION
Since we're counting effects rather than variants generating effects, we might end up double-counting variants.

This does not appear to impact our bladder analyses.

@arahuja does this change make sense to you?
