### PR TITLE
modify setup.py to reference requirements.txt

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,11 +40,11 @@ except ImportError as e:
     pass
 
 # get the dependencies and installs
-with open(path.join(current_directory, 'requirements.txt'), encoding='utf-8') as f:
+with open(path.join(current_directory, "requirements.txt"), encoding='utf-8') as f:
     all_reqs = f.read().split('\n')
 
-install_requires = [x.strip() for x in all_reqs if 'git+' not in x]
-dependency_links = [x.strip().replace('git+','') for x in all_reqs if 'git+' in x]
+install_requires = [req.strip() for req in all_reqs if 'git+' not in req]
+dependency_links = [req.strip().replace('git+','') for req in all_reqs if 'git+' in req]
 
 if __name__ == "__main__":
     setup(

--- a/setup.py
+++ b/setup.py
@@ -14,9 +14,12 @@
 
 from __future__ import print_function
 import os
+from os import path
+from codecs import open
 from setuptools import setup
 import versioneer
 
+here = path.abspath(path.dirname(__file__))
 current_directory = os.path.dirname(__file__)
 readme_filename = "README.md"
 readme_path = os.path.join(current_directory, readme_filename)
@@ -37,6 +40,12 @@ except ImportError as e:
     print("Failed to convert %s to reStructuredText", readme_filename)
     pass
 
+# get the dependencies and installs
+with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
+    all_reqs = f.read().split('\n')
+
+install_requires = [x.strip() for x in all_reqs if 'git+' not in x]
+dependency_links = [x.strip().replace('git+','') for x in all_reqs if 'git+' in x]
 
 if __name__ == "__main__":
     setup(
@@ -57,23 +66,8 @@ if __name__ == "__main__":
             "Programming Language :: Python",
             "Topic :: Scientific/Engineering :: Bio-Informatics",
         ],
-        install_requires=[
-            "pandas>=0.15",
-            "seaborn>=0.7.0",
-            "scipy>=0.17.0",
-            "topiary>=0.0.20",
-            "mhctools>=0.2.3",
-            "varcode>=0.4.12",
-            "pyensembl>=0.8.12",
-            "six>=1.10.0",
-            "lifelines>=0.9.1.0",
-            "scikit-learn>=0.17.1",
-            "vcf-annotate-polyphen>=0.1.2",
-            "patsy>=0.4.1"
-        ],
-        dependency_links=[
-            "git+git://github.com/hammerlab/isovar",
-        ],
+        install_requires=install_requires,
+        dependency_links=dependency_links,
         long_description=readme,
         packages=["cohorts"],
     )

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,6 @@ from codecs import open
 from setuptools import setup
 import versioneer
 
-here = path.abspath(path.dirname(__file__))
 current_directory = os.path.dirname(__file__)
 readme_filename = "README.md"
 readme_path = os.path.join(current_directory, readme_filename)
@@ -41,7 +40,7 @@ except ImportError as e:
     pass
 
 # get the dependencies and installs
-with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
+with open(path.join(current_directory, 'requirements.txt'), encoding='utf-8') as f:
     all_reqs = f.read().split('\n')
 
 install_requires = [x.strip() for x in all_reqs if 'git+' not in x]


### PR DESCRIPTION
I modified `setup.py` to load install_requires from `requirements.txt`. 

This should address situations like that seen in issue #69, which we thought we had fixed (by freezing `isovar` version) but it turned out we hadn't truly fixed -- we only changed isovar in `requirements.txt` but not in `setup.py`. Since requirements.ext was used to set up the travis testing environment, this failure to modify `setup.py` wasn't caught.

One downside of loading all packages from `requirements.txt` into `setup.py` is that we end up with utility packages like `pylint` included as requirements for cohorts. Same would go for packages required for testing, which may or may not be required for package function.

We could avoid this situation by having separate "package_requirements.txt" & "travis_requirements.txt" files, only one of which would be used to populate `setup.py`.  But, maintaining separate files introduces the potential for the problem to re-occur.  

Packages like `pylint` are hard-coded into the .travis-ci.yml and so could probably be taken out of this `requirements.txt` file entirely.
