### PR TITLE
Report data sources

### DIFF
--- a/cohorts/load.py
+++ b/cohorts/load.py
@@ -267,6 +267,7 @@ class Cohort(Collection):
                             "expressed_neoantigen": "cached-expressed-neoantigens",
                             "polyphen": "cached-polyphen-annotations",
                             "isovar": "cached-isovar-output"}
+        print(self.summarize_provenance())
 
     def verify_id_uniqueness(self):
         patient_ids = set([patient.id for patient in self])

--- a/cohorts/load.py
+++ b/cohorts/load.py
@@ -20,6 +20,7 @@ import pandas as pd
 import seaborn as sb
 import json
 import warnings
+import pprint
 
 # pylint doesn't like this line
 # pylint: disable=no-name-in-module
@@ -267,7 +268,7 @@ class Cohort(Collection):
                             "expressed_neoantigen": "cached-expressed-neoantigens",
                             "polyphen": "cached-polyphen-annotations",
                             "isovar": "cached-isovar-output"}
-        print(self.summarize_provenance())
+        pprint.pprint(self.summarize_data_sources())
 
     def verify_id_uniqueness(self):
         patient_ids = set([patient.id for patient in self])


### PR DESCRIPTION
Implemented #80 - summarize provenance on init. 

Prints a summary of data sources on initialization, so that analyses using the cohort data are earmarked with the version of data used for analysis.
