### PR TITLE
first draft of clean_column_names utility function

### DIFF
--- a/cohorts/load.py
+++ b/cohorts/load.py
@@ -328,7 +328,8 @@ class Cohort(Collection):
         self.dataframe_hash = hash(str(df.sort_values("patient_id")))
         return df
 
-    def as_dataframe(self, on=None, col=None, join_with=None, join_how=None, **kwargs):
+    def as_dataframe(self, on=None, col=None, join_with=None, join_how=None,
+                    rename_cols=False, keep_paren_contents=True, **kwargs):
         """
         Return this Cohort as a DataFrame, and optionally include additional columns
         using `on`.
@@ -345,6 +346,18 @@ class Cohort(Collection):
 
         If `on` is a function or functions, kwargs is passed to those functions.
         Otherwise kwargs is ignored.
+
+        Other parameters
+        ----------------
+        `rename_cols`: (bool)
+                if True, then return columns using "clean" column names
+                ("clean" means lower-case names without punctuation other than `_`)
+                defaults to False
+        `keep_paren_contents`: (bool)
+                if True, then contents of column names within parens are kept.
+                if False, contents of column names within-parens are dropped.
+                Defaults to True
+        ----------
 
         Return : tuple or DataFrame
             <dataframe>
@@ -397,14 +410,13 @@ class Cohort(Collection):
             for key, value in on.iteritems():
                 col, df = apply_func(on=value, col=key, df=df)
                 cols.append(col)
-            return (cols, df)
         if type(on) == list:
             cols = []
             for i, elem in enumerate(on):
                 col = elem.__name__ if not is_lambda(elem) else "column_%d" % i
                 col, df = apply_func(on=elem, col=col, df=df)
                 cols.append(col)
-            return (cols, df)
+        return (cols, df)
 
     def load_dataframe(self, df_loader_name):
         """

--- a/cohorts/load.py
+++ b/cohorts/load.py
@@ -330,7 +330,7 @@ class Cohort(Collection):
         return df
 
     def as_dataframe(self, on=None, col=None, join_with=None, join_how=None,
-                    rename_cols=False, keep_paren_contents=True, **kwargs):
+                     rename_cols=False, keep_paren_contents=True, **kwargs):
         """
         Return this Cohort as a DataFrame, and optionally include additional columns
         using `on`.
@@ -351,14 +351,14 @@ class Cohort(Collection):
         Other parameters
         ----------------
         `rename_cols`: (bool)
-                if True, then return columns using "stripped" column names
-                ("stripped" means lower-case names without punctuation other than `_`)
-                See `utils.strip_column_names` for more details
-                defaults to False
+            if True, then return columns using "stripped" column names
+            ("stripped" means lower-case names without punctuation other than `_`)
+            See `utils.strip_column_names` for more details
+            defaults to False
         `keep_paren_contents`: (bool)
-                if True, then contents of column names within parens are kept.
-                if False, contents of column names within-parens are dropped.
-                Defaults to True
+            if True, then contents of column names within parens are kept.
+            if False, contents of column names within-parens are dropped.
+            Defaults to True
         ----------
 
         Return : tuple or DataFrame
@@ -420,8 +420,7 @@ class Cohort(Collection):
                 cols.append(col)
 
         if (rename_cols):
-            df = df.rename(columns=_strip_column_names(df.columns,
-                   keep_paren_contents=keep_paren_contents))
+            df = df.rename(columns=_strip_column_names(df.columns, keep_paren_contents=keep_paren_contents))
         return (cols, df)
 
     def load_dataframe(self, df_loader_name):

--- a/cohorts/load.py
+++ b/cohorts/load.py
@@ -38,6 +38,7 @@ from topiary.sequence_helpers import contains_mutant_residues
 from isovar.protein_sequence import variants_to_protein_sequences_dataframe
 from pysam import AlignmentFile
 
+from .utils import strip_column_names as _strip_column_names
 from .survival import plot_kmf
 from .plot import mann_whitney_plot, fishers_exact_plot, roc_curve_plot
 from .collection import Collection
@@ -350,8 +351,9 @@ class Cohort(Collection):
         Other parameters
         ----------------
         `rename_cols`: (bool)
-                if True, then return columns using "clean" column names
-                ("clean" means lower-case names without punctuation other than `_`)
+                if True, then return columns using "stripped" column names
+                ("stripped" means lower-case names without punctuation other than `_`)
+                See `utils.strip_column_names` for more details
                 defaults to False
         `keep_paren_contents`: (bool)
                 if True, then contents of column names within parens are kept.
@@ -416,6 +418,10 @@ class Cohort(Collection):
                 col = elem.__name__ if not is_lambda(elem) else "column_%d" % i
                 col, df = apply_func(on=elem, col=col, df=df)
                 cols.append(col)
+
+        if (rename_cols):
+            df = df.rename(columns=_strip_column_names(d.columns,
+                   keep_paren_contents=keep_paren_contents))
         return (cols, df)
 
     def load_dataframe(self, df_loader_name):

--- a/cohorts/load.py
+++ b/cohorts/load.py
@@ -420,7 +420,7 @@ class Cohort(Collection):
                 cols.append(col)
 
         if (rename_cols):
-            df = df.rename(columns=_strip_column_names(d.columns,
+            df = df.rename(columns=_strip_column_names(df.columns,
                    keep_paren_contents=keep_paren_contents))
         return (cols, df)
 

--- a/cohorts/load.py
+++ b/cohorts/load.py
@@ -420,7 +420,9 @@ class Cohort(Collection):
                 cols.append(col)
 
         if (rename_cols):
-            df = df.rename(columns=_strip_column_names(df.columns, keep_paren_contents=keep_paren_contents))
+            rename_dict = _strip_column_names(df.columns, keep_paren_contents=keep_paren_contents)
+            df.rename(columns=rename_dict, inplace=True)
+            cols = [rename_dict[col] for col in cols]
         return (cols, df)
 
     def load_dataframe(self, df_loader_name):

--- a/cohorts/utils.py
+++ b/cohorts/utils.py
@@ -16,10 +16,10 @@ import re
 import logging
 
 
-def _clean_column_name(col_name, keep_paren_contents=True):
+def _strip_column_name(col_name, keep_paren_contents=True):
     """
     Utility script applying several regexs to a string.
-    Intended to be used by `clean_column_names`.
+    Intended to be used by `strip_column_names`.
 
     This function will:
         1. replace informative punctuation components with text
@@ -41,7 +41,7 @@ def _clean_column_name(col_name, keep_paren_contents=True):
 
     Examples
     --------
-    > print([_clean_column_name(col) for col in ['PD-L1','PD L1','PD L1_']])
+    > print([_strip_column_name(col) for col in ['PD-L1','PD L1','PD L1_']])
     """
     # start with input
     new_col_name = col_name
@@ -77,12 +77,13 @@ def _clean_column_name(col_name, keep_paren_contents=True):
     return new_col_name.lower()
 
 
-def clean_column_names(cols, keep_paren_contents=True):
+def strip_column_names(cols, keep_paren_contents=True):
     """
     Utility script for renaming pandas columns to patsy-friendly names.
-    Revised names have:
-        - punctuation and whitespace -> text or _
-        - all text in lower case
+
+    Revised names have been:
+        - stripped of all punctuation and whitespace (converted to text or `_`)
+        - converted to lower case
 
     Takes a list of column names, returns a dict mapping
     names to revised names.
@@ -113,21 +114,22 @@ def clean_column_names(cols, keep_paren_contents=True):
       'PD L1 (>1)': pd.Series([0., 1., 1., 0.], index=['a', 'b', 'c', 'd']),
       }
     > df = pd.DataFrame(df)
-    > df = df.rename(columns = clean_column_names(df.columns))
+    > df = df.rename(columns = strip_column_names(df.columns))
 
     ## observe, by comparison
-    > df2 = df.rename(columns = clean_column_names(df.columns,
+    > df2 = df.rename(columns = strip_column_names(df.columns,
         keep_paren_contents=False))
     """
     logger = logging.getLogger()
 
-    # clean/replace punctuation
+    # strip/replace punctuation
     new_cols = [
-        _clean_column_name(col, keep_paren_contents=keep_paren_contents)
+        _strip_column_name(col, keep_paren_contents=keep_paren_contents)
         for col in cols]
 
     if not(len(new_cols) == len(set(new_cols))):
-        logger.warning('Warning: clean_column_names will introduce duplicate names. Reverting column names to the original.')
+        logger.warning('Warning: strip_column_names (if run) would introduce duplicate names.'
+            ' Reverting column names to the original.')
         return dict(zip(cols, cols))
 
     return dict(zip(cols, new_cols))

--- a/cohorts/utils.py
+++ b/cohorts/utils.py
@@ -38,7 +38,7 @@ def _clean_column_name(x, keep_parens = True):
 
         Examples
         --------- 
-        > print([clean_column_name(col) for col in ['PD-L1','PD L1','PD L1_']])
+        > print([_clean_column_name(col) for col in ['PD-L1','PD L1','PD L1_']])
 
     """
     ## start with input

--- a/cohorts/utils.py
+++ b/cohorts/utils.py
@@ -14,6 +14,7 @@
 
 import re
 import logging
+import warnings
 
 
 def _strip_column_name(col_name, keep_paren_contents=True):
@@ -128,8 +129,11 @@ def strip_column_names(cols, keep_paren_contents=True):
         for col in cols]
 
     if not(len(new_cols) == len(set(new_cols))):
-        logger.warning('Warning: strip_column_names (if run) would introduce duplicate names.'
-                       ' Reverting column names to the original.')
+        warn_str = 'Warning: strip_column_names (if run) would introduce duplicate names.'
+        warn_str += ' Reverting column names to the original.'
+
+        logger.warning(warn_str)
+        warnings.warn(warn_str)
         print('Warning: strip_column_names would introduce duplicate names. Please fix & try again.')
         return dict(zip(cols, cols))
 

--- a/cohorts/utils.py
+++ b/cohorts/utils.py
@@ -128,7 +128,7 @@ def strip_column_names(cols, keep_paren_contents=True):
         _strip_column_name(col, keep_paren_contents=keep_paren_contents)
         for col in cols]
 
-    if not(len(new_cols) == len(set(new_cols))):
+    if len(new_cols) != len(set(new_cols)):
         warn_str = 'Warning: strip_column_names (if run) would introduce duplicate names.'
         warn_str += ' Reverting column names to the original.'
 

--- a/cohorts/utils.py
+++ b/cohorts/utils.py
@@ -12,113 +12,122 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import re 
+import re
+import logging
 
-def _clean_column_name(x, keep_parens = True):
+
+def _clean_column_name(col_name, keep_paren_contents=True):
     """
-        Utility script applying several regexs to a string.  Intended to be used by `clean_column_names`.
+    Utility script applying several regexs to a string.
+    Intended to be used by `clean_column_names`.
 
-        This function will: 
-            1. replace informative punctuation components with text
-            2. (optionally) remove text within parentheses
-            3. replace remaining punctuation/whitespace with _
-            4. remove trailing punctuation/whitespace
+    This function will:
+        1. replace informative punctuation components with text
+        2. (optionally) remove text within parentheses
+        3. replace remaining punctuation/whitespace with _
+        4. remove trailing punctuation/whitespace
 
-        Parameters 
-        -----------
-        str (str): input character string
-        keep_parens (logical): control behavior of within-paren elements of text
-             - if True, (the default) all text within parens retained
-             - if False, text within parens will be removed from the field name
+    Parameters
+    ----------
+    col_name (str): input character string
+    keep_paren_contents (logical):
+        controls behavior of within-paren elements of text
+         - if True, (the default) all text within parens retained
+         - if False, text within parens will be removed from the field name
 
-        Returns
-        --------
-        modified string for new field name 
+    Returns
+    --------
+    modified string for new field name
 
-
-        Examples
-        --------- 
-        > print([_clean_column_name(col) for col in ['PD-L1','PD L1','PD L1_']])
-
+    Examples
+    --------
+    > print([_clean_column_name(col) for col in ['PD-L1','PD L1','PD L1_']])
     """
-    ## start with input
-    newx = x
-    
-    ## replace meaningful punctuation with text equivalents
-    ## surround each with whitespace to enforce consistent use of _
-    newx = re.sub('<=', ' le ', newx)
-    newx = re.sub('=<', ' le ', newx)
-    newx = re.sub('>=', ' ge ', newx)
-    newx = re.sub('=>', ' ge ', newx)
-    newx = re.sub('<', ' lt ', newx)
-    newx = re.sub('>', ' gt ', newx)
-    newx = re.sub('#', ' num ', newx)
-    
-    ## remove contents within ()
-    if not(keep_parens):
-        newx = re.sub('\([^)]*\)', '', newx)
-    
-    ## replace remaining punctuation/whitespace with _
+    # start with input
+    new_col_name = col_name
+    # replace meaningful punctuation with text equivalents
+    # surround each with whitespace to enforce consistent use of _
+    punctuation_to_text = {
+        '<=': 'le',
+        '>=': 'ge',
+        '=<': 'le',
+        '=>': 'ge',
+        '<': 'lt',
+        '>': 'gt',
+        '#': 'num'
+    }
+    for punctuation, punctuation_text in punctuation_to_text.items():
+        new_col_name = new_col_name.replace(punctuation, punctuation_text)
+
+    # remove contents within ()
+    if not(keep_paren_contents):
+        new_col_name = re.sub('\([^)]*\)', '', new_col_name)
+
+    # replace remaining punctuation/whitespace with _
     punct_pattern = '[\W_]+'
     punct_replacement = '_'
-    newx = re.sub(punct_pattern, punct_replacement, newx)
-    
-    ## remove trailing _ if it exists (if last char was punctuation)
-    newx = re.sub('_$', '', newx)
-    return newx
+    new_col_name = re.sub(punct_pattern, punct_replacement, new_col_name)
 
-def clean_column_names(cols, keep_parens = True):
+    # remove trailing _ if it exists (if last char was punctuation)
+    new_col_name = re.sub('_$', '', new_col_name)
+
+    # TODO: check for empty string
+
+    # return lower-case version of column name
+    return new_col_name.lower()
+
+
+def clean_column_names(cols, keep_paren_contents=True):
     """
-        Utility script for renaming pandas columns to patsy-friendly names.
-        
-        Revised names have:
-            - punctuation and whitespace -> text or _
-            - all text in lower case 
+    Utility script for renaming pandas columns to patsy-friendly names.
+    Revised names have:
+        - punctuation and whitespace -> text or _
+        - all text in lower case
 
-        Takes a list of column names, returns a dictionary mapping names to revised names.
+    Takes a list of column names, returns a dict mapping
+    names to revised names.
 
-        If there are any concerns with the conversion, this will print a warning & return original column names. 
-        
-        Parameters 
-        --------------
-            cols (list): list of strings containing column names
-            keep_parens (logical): whether to retain text within parentheses (defalt: True)
+    If there are any concerns with the conversion, this will
+    print a warning & return original column names.
 
-        Returns
-        --------
-            dict mapping cols -> newcols
+    Parameters
+    ----------
 
-        Example 
-        -------- 
-        > d = {'one' : pd.Series([1., 2., 3.], index=['a', 'b', 'c']),
-              'two' : pd.Series([1., 2., 3., 4.], index=['a', 'b', 'c', 'd']),
-              'PD L1 (value)': pd.Series([1., 2., 3., 4.], index=['a', 'b', 'c', 'd']),
-              'PD L1 (>1)': pd.Series([0., 1., 1., 0.], index=['a', 'b', 'c', 'd']),
-              }
-        > d = pd.DataFrame(d)
-        > d = d.rename(columns = clean_column_names(d.columns))
-        
-        ## observe, by comparison
-        > d2 = d.rename(columns = clean_column_names(d.columns, keep_parens = False))
+    cols (list): list of strings containing column names
+    keep_paren_contents (logical):
+        controls behavior of within-paren elements of text
+         - if True, (the default) all text within parens retained
+         - if False, text within parens will be removed from the field name
 
+    Returns
+    -------
+
+    dict mapping cols -> newcols
+
+    Example
+    -------
+
+    > df = {'one' : pd.Series([1., 2., 3.], index=['a', 'b', 'c']),
+      'two' : pd.Series([1., 2., 3., 4.], index=['a', 'b', 'c', 'd']),
+      'PD L1 (value)': pd.Series([1., 2., 3., 4.], index=['a', 'b', 'c', 'd']),
+      'PD L1 (>1)': pd.Series([0., 1., 1., 0.], index=['a', 'b', 'c', 'd']),
+      }
+    > df = pd.DataFrame(df)
+    > df = df.rename(columns = clean_column_names(df.columns))
+
+    ## observe, by comparison
+    > df2 = df.rename(columns = clean_column_names(df.columns,
+        keep_paren_contents=False))
     """
-    ## clean/replace punctuation
-    newcols = [_clean_column_name(col, keep_parens = keep_parens) for col in cols]
-    
-    ## confirm no duplicates in remaining columns
-    if not(len(newcols) == len(cols)):
-        print('Warning: length of newcols not the same as cols')
+    logger = logging.getLogger()
+
+    # clean/replace punctuation
+    new_cols = [
+        _clean_column_name(col, keep_paren_contents=keep_paren_contents)
+        for col in cols]
+
+    if not(len(new_cols) == len(set(new_cols))):
+        logger.warning('Warning: clean_column_names will introduce duplicate names. Reverting column names to the original.')
         return dict(zip(cols, cols))
-    
-    if not(len(newcols) == len(set(newcols))):
-        print('Warning: cleanup introduces duplicate names. Please resolve & try again.')
-        return dict(zip(cols, cols))
-    
-    ## modify all column names to lower case
-    newcols_lc = [col.lower() for col in newcols]
-    if not(len(newcols_lc) == len(set(newcols_lc))):
-        print('Warning: changing case introduces duplicate names. Skipping this.')
-    else:
-        newcols = newcols_lc
-    
-    return dict(zip(cols, newcols))
+
+    return dict(zip(cols, new_cols))

--- a/cohorts/utils.py
+++ b/cohorts/utils.py
@@ -1,0 +1,124 @@
+# Copyright (c) 2016. Mount Sinai School of Medicine
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import re 
+
+def _clean_column_name(x, keep_parens = True):
+    """
+        Utility script applying several regexs to a string.  Intended to be used by `clean_column_names`.
+
+        This function will: 
+            1. replace informative punctuation components with text
+            2. (optionally) remove text within parentheses
+            3. replace remaining punctuation/whitespace with _
+            4. remove trailing punctuation/whitespace
+
+        Parameters 
+        -----------
+        str (str): input character string
+        keep_parens (logical): control behavior of within-paren elements of text
+             - if True, (the default) all text within parens retained
+             - if False, text within parens will be removed from the field name
+
+        Returns
+        --------
+        modified string for new field name 
+
+
+        Examples
+        --------- 
+        > print([clean_column_name(col) for col in ['PD-L1','PD L1','PD L1_']])
+
+    """
+    ## start with input
+    newx = x
+    
+    ## replace meaningful punctuation with text equivalents
+    ## surround each with whitespace to enforce consistent use of _
+    newx = re.sub('<=', ' le ', newx)
+    newx = re.sub('=<', ' le ', newx)
+    newx = re.sub('>=', ' ge ', newx)
+    newx = re.sub('=>', ' ge ', newx)
+    newx = re.sub('<', ' lt ', newx)
+    newx = re.sub('>', ' gt ', newx)
+    newx = re.sub('#', ' num ', newx)
+    
+    ## remove contents within ()
+    if not(keep_parens):
+        newx = re.sub('\([^)]*\)', '', newx)
+    
+    ## replace remaining punctuation/whitespace with _
+    punct_pattern = '[\W_]+'
+    punct_replacement = '_'
+    newx = re.sub(punct_pattern, punct_replacement, newx)
+    
+    ## remove trailing _ if it exists (if last char was punctuation)
+    newx = re.sub('_$', '', newx)
+    return newx
+
+def clean_column_names(cols, keep_parens = True):
+    """
+        Utility script for renaming pandas columns to patsy-friendly names.
+        
+        Revised names have:
+            - punctuation and whitespace -> text or _
+            - all text in lower case 
+
+        Takes a list of column names, returns a dictionary mapping names to revised names.
+
+        If there are any concerns with the conversion, this will print a warning & return original column names. 
+        
+        Parameters 
+        --------------
+            cols (list): list of strings containing column names
+            keep_parens (logical): whether to retain text within parentheses (defalt: True)
+
+        Returns
+        --------
+            dict mapping cols -> newcols
+
+        Example 
+        -------- 
+        > d = {'one' : pd.Series([1., 2., 3.], index=['a', 'b', 'c']),
+              'two' : pd.Series([1., 2., 3., 4.], index=['a', 'b', 'c', 'd']),
+              'PD L1 (value)': pd.Series([1., 2., 3., 4.], index=['a', 'b', 'c', 'd']),
+              'PD L1 (>1)': pd.Series([0., 1., 1., 0.], index=['a', 'b', 'c', 'd']),
+              }
+        > d = pd.DataFrame(d)
+        > d = d.rename(columns = clean_column_names(d.columns))
+        
+        ## observe, by comparison
+        > d2 = d.rename(columns = clean_column_names(d.columns, keep_parens = False))
+
+    """
+    ## clean/replace punctuation
+    newcols = [_clean_column_name(col, keep_parens = keep_parens) for col in cols]
+    
+    ## confirm no duplicates in remaining columns
+    if not(len(newcols) == len(cols)):
+        print('Warning: length of newcols not the same as cols')
+        return dict(zip(cols, cols))
+    
+    if not(len(newcols) == len(set(newcols))):
+        print('Warning: cleanup introduces duplicate names. Please resolve & try again.')
+        return dict(zip(cols, cols))
+    
+    ## modify all column names to lower case
+    newcols_lc = [col.lower() for col in newcols]
+    if not(len(newcols_lc) == len(set(newcols_lc))):
+        print('Warning: changing case introduces duplicate names. Skipping this.')
+    else:
+        newcols = newcols_lc
+    
+    return dict(zip(cols, newcols))

--- a/cohorts/utils.py
+++ b/cohorts/utils.py
@@ -129,7 +129,8 @@ def strip_column_names(cols, keep_paren_contents=True):
 
     if not(len(new_cols) == len(set(new_cols))):
         logger.warning('Warning: strip_column_names (if run) would introduce duplicate names.'
-            ' Reverting column names to the original.')
+                       ' Reverting column names to the original.')
+        print('Warning: strip_column_names would introduce duplicate names. Please fix & try again.')
         return dict(zip(cols, cols))
 
     return dict(zip(cols, new_cols))

--- a/cohorts/utils.py
+++ b/cohorts/utils.py
@@ -25,7 +25,7 @@ def _clean_column_name(col_name, keep_paren_contents=True):
         1. replace informative punctuation components with text
         2. (optionally) remove text within parentheses
         3. replace remaining punctuation/whitespace with _
-        4. remove trailing punctuation/whitespace
+        4. strip leading/trailing punctuation/whitespace
 
     Parameters
     ----------
@@ -68,8 +68,8 @@ def _clean_column_name(col_name, keep_paren_contents=True):
     punct_replacement = '_'
     new_col_name = re.sub(punct_pattern, punct_replacement, new_col_name)
 
-    # remove trailing _ if it exists (if last char was punctuation)
-    new_col_name = re.sub('_$', '', new_col_name)
+    # remove leading/trailing _ if it exists (if last char was punctuation)
+    new_col_name = new_col_name.strip("_")
 
     # TODO: check for empty string
 

--- a/cohorts/utils.py
+++ b/cohorts/utils.py
@@ -104,7 +104,7 @@ def strip_column_names(cols, keep_paren_contents=True):
     Returns
     -------
 
-    dict mapping cols -> newcols
+    dict mapping col_names -> new_col_names
 
     Example
     -------

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -17,6 +17,7 @@ from cohorts.utils import strip_column_names, _strip_column_name
 from cohorts import DataFrameLoader, Cohort, Patient
 import warnings
 
+from . import generated_data_path
 from .functions import *
 
 from nose.tools import eq_, ok_
@@ -39,8 +40,8 @@ def make_alt_simple_cohort(merge_type="union", **kwargs):
     patients = []
     for i, row in clinical_dataframe.iterrows():
         patient = Patient(id=row["id"],
-                          os=row["OS"],
-                          pfs=row["PFS"],
+                          os=row["os"],
+                          pfs=row["pfs"],
                           deceased=row["deceased"],
                           progressed_or_deceased=row["progressed_or_deceased"],
                           additional_data=row

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -43,14 +43,6 @@ def test_strip_column_names():
     ok_((df3.columns == df.columns).all())
 
 
-def test_as_dataframe_generic():
-    cohort = prep_test_cohort()
-    # test that column names haven't changed
-    df = cohort.as_dataframe(join_with="hello")
-    # column names should match those in df_hello
-    ok_([col in df_hello.columns for col in df.columns])
-
-
 def prep_test_cohort():
     cohort = make_simple_cohort()
     df_hello = pd.DataFrame({
@@ -65,17 +57,26 @@ def prep_test_cohort():
         return df_hello
     df_loader = DataFrameLoader("hello", load_df, join_on="the_id")
     cohort.df_loaders = [df_loader]
-    return cohort
+    return df_hello, cohort
+
+
+def test_as_dataframe_generic():
+    df_hello, cohort = prep_test_cohort()
+    # test that column names haven't changed
+    df = cohort.as_dataframe(join_with="hello")
+    # column names should match those in df_hello
+    ok_([col in df_hello.columns for col in df.columns])
+
 
 def test_as_dataframe_rename():
-    cohort = prep_test_cohort()
+    df_hello, cohort = prep_test_cohort()
     # test behavior with rename_cols=True
     df2 = cohort.as_dataframe(rename_cols=True, join_with='hello')
     eq_(df2.columns, ['one', 'two', 'pd_l1_val', 'pd_l1_gt_1', 'the_id'])
 
 
 def test_as_dataframe_drop_parens():
-    cohort = prep_test_cohort()
+    df_hello, cohort = prep_test_cohort()
     # test behavior with keep_paren_contents=False
     df3 = cohort.as_dataframe(rename_cols=True, keep_paren_contents=False, join_with='hello')
     # column names should match those in df_hello

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -17,13 +17,10 @@ from cohorts.utils import strip_column_names, _strip_column_name
 from cohorts import DataFrameLoader, Cohort, Patient
 import warnings
 
-from . import data_path, generated_data_path, DATA_DIR
-from .data_generate import generate_vcfs
 from .functions import *
 
 from nose.tools import eq_, ok_
 from .test_basic import make_simple_cohort
-from sets import Set
 
 def make_alt_simple_clinical_dataframe(
         os_list=None,

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -71,13 +71,14 @@ def test_as_dataframe_generic():
 def test_as_dataframe_rename():
     df_hello, cohort = prep_test_cohort()
     # test behavior with rename_cols=True
-    df2 = cohort.as_dataframe(rename_cols=True, join_with='hello')
-    eq_(df2.columns, ['one', 'two', 'pd_l1_val', 'pd_l1_gt_1', 'the_id'])
+    df = cohort.as_dataframe(rename_cols=True, join_with='hello')
+    expected = ['one', 'two', 'pd_l1_val', 'pd_l1_gt_1', 'the_id']
+    ok_([name in df.columns for name in expected])
 
 
 def test_as_dataframe_drop_parens():
     df_hello, cohort = prep_test_cohort()
     # test behavior with keep_paren_contents=False
-    df3 = cohort.as_dataframe(rename_cols=True, keep_paren_contents=False, join_with='hello')
+    df = cohort.as_dataframe(rename_cols=True, keep_paren_contents=False, join_with='hello')
     # column names should match those in df_hello
-    ok_((df3.columns == df_hello.columns).all())
+    ok_([col in df_hello.columns for col in df.columns])

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -30,9 +30,11 @@ def test_column_names():
          'PD L1 (>1)': pd.Series([0., 1., 1., 1.], index=['a', 'b', 'c', 'd']),
          }
     df = pd.DataFrame(d)
+
     # should not error & should rename columns
     df2 = df.rename(columns=clean_column_names(df.columns))
     ok_((df2.columns != df.columns).any())
+
     # should not rename columns -- should error
     df3 = d.rename(columns=clean_column_names(
         df.columns, keep_paren_contents=False))

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -18,7 +18,7 @@ from cohorts import DataFrameLoader
 
 from nose.tools import eq_, ok_
 from .test_basic import make_simple_cohort
-
+from sets import Set
 
 def test_strip_single_column_name():
     res = [_strip_column_name(col) for col in ['PD-L1', 'PD L1', 'PD L1_']]
@@ -65,15 +65,22 @@ def test_as_dataframe_generic():
     # test that column names haven't changed
     df = cohort.as_dataframe(join_with="hello")
     # column names should match those in df_hello
-    ok_([col in df_hello.columns for col in df.columns])
+    expected = Set(df_hello.columns)
+    returned = Set(df.columns)
+    print('Expected:', expected)
+    print('Returned:', returned)
+    ok_(expected.issubset(returned))
 
 
 def test_as_dataframe_rename():
     df_hello, cohort = prep_test_cohort()
     # test behavior with rename_cols=True
     df = cohort.as_dataframe(rename_cols=True, join_with='hello')
-    expected = ['one', 'two', 'pd_l1_val', 'pd_l1_gt_1', 'the_id']
-    ok_([name in df.columns for name in expected])
+    expected = Set(['one', 'two', 'pd_l1_val', 'pd_l1_gt_1', 'the_id'])
+    returned = Set(df.columns)
+    print('Expected:', expected)
+    print('Returned:', returned)
+    ok_(expected.issubset(returned))
 
 
 def test_as_dataframe_drop_parens():
@@ -81,4 +88,8 @@ def test_as_dataframe_drop_parens():
     # test behavior with keep_paren_contents=False
     df = cohort.as_dataframe(rename_cols=True, keep_paren_contents=False, join_with='hello')
     # column names should match those in df_hello
-    ok_([col in df_hello.columns for col in df.columns])
+    expected = Set(df_hello.columns)
+    returned = Set(df.columns)
+    print('Expected:', expected)
+    print('Returned:', returned)
+    ok_(expected.issubset(returned))

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -25,15 +25,12 @@ def test_column_names():
     d = {'one' : pd.Series([1., 2., 3.], index=['a', 'b', 'c']),
       'two' : pd.Series([1., 2., 3., 4.], index=['a', 'b', 'c', 'd']),
       'PD L1 (value)': pd.Series([1., 2., 3., 4.], index=['a', 'b', 'c', 'd']),
-      'PD L1 (>1)': pd.Series([0., 1., 1., 0.], index=['a', 'b', 'c', 'd']),
+      'PD L1 (>1)': pd.Series([0., 1., 1., 1.], index=['a', 'b', 'c', 'd']),
       }
-    d = pd.DataFrame(d)
+    df = pd.DataFrame(d)
     ## should not error & should rename columns
-    d2 = d.rename(columns = clean_column_names(d.columns))
-    ok_(d2.columns != d.columns)
-
+    df2 = df.rename(columns = clean_column_names(df.columns))
+    ok_(df2.columns != df.columns)
     ## should not rename columns -- should error
-    d3 = d.rename(columns = clean_column_names(d.columns, keep_parens = False))
-    eq_(d3.columns, d.columns)
-
-
+    df3 = d.rename(columns = clean_column_names(df.columns, keep_paren_contents = False))
+    eq_(df3.columns, df.columns)

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -14,9 +14,11 @@
 
 import pandas as pd
 from cohorts.utils import strip_column_names, _strip_column_name
+from cohorts import DataFrameLoader
 
 from nose.tools import eq_, ok_
 from .test_basic import make_simple_cohort
+
 
 def test_strip_single_column_name():
     res = [_strip_column_name(col) for col in ['PD-L1', 'PD L1', 'PD L1_']]
@@ -40,14 +42,17 @@ def test_strip_column_names():
         df.columns, keep_paren_contents=False))
     ok_((df3.columns == df.columns).all())
 
+
 def test_as_dataframe():
     cohort = make_simple_cohort()
-    df_hello = pd.DataFrame({'one': pd.Series([1., 2., 3.], index=['a', 'b', 'c']),
-         'two': pd.Series([1., 2., 3., 4.], index=['a', 'b', 'c', 'd']),
-         'PD L1 (val)': pd.Series([1., 2., 3., 4.], index=['a', 'b', 'c', 'd']),
-         'PD L1 (>1)': pd.Series([0., 1., 1., 1.], index=['a', 'b', 'c', 'd']),
-         'the_id': ['1', '5', '7'],
-         })
+    df_hello = pd.DataFrame({
+        'one': [1., 2., 3.],
+        'two': [1., 2., 3.],
+        'PD L1 (val)': [1., 2., 3.],
+        'PD L1 (>1)': [0., 1., 1.],
+        'the_id': ['1', '5', '7'],
+        })
+
     def load_df():
         return df_hello
     df_loader = DataFrameLoader("hello", load_df, join_on="the_id")
@@ -60,7 +65,7 @@ def test_as_dataframe():
 
     # test behavior with rename_cols=True
     df2 = cohort.as_dataframe(rename_cols=True)
-    eq_(df2.columns, ['one','two','pd_l1_val','pd_l1_gt_1','the_id'])
+    eq_(df2.columns, ['one', 'two', 'pd_l1_val', 'pd_l1_gt_1', 'the_id'])
 
     # test behavior with keep_paren_contents=False
     df3 = cohort.as_dataframe(rename_cols=True, keep_paren_contents=False)

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -20,7 +20,7 @@ from nose.tools import eq_, ok_
 
 def test_clean_column_name():
     res = [_clean_column_name(col) for col in ['PD-L1', 'PD L1', 'PD L1_']]
-    eq_(res, ['PD_L1', 'PD_L1', 'PD_L1'])
+    eq_(res, ['pd_l1', 'pd_l1', 'pd_l1'])
 
 
 def test_column_names():
@@ -36,6 +36,6 @@ def test_column_names():
     ok_((df2.columns != df.columns).any())
 
     # should not rename columns -- should error
-    df3 = d.rename(columns=clean_column_names(
+    df3 = df.rename(columns=clean_column_names(
         df.columns, keep_paren_contents=False))
-    eq_((df3.columns, df.columns).all())
+    ok_((df3.columns == df.columns).all())

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -16,7 +16,7 @@ import pandas as pd
 from cohorts.utils import strip_column_names, _strip_column_name
 
 from nose.tools import eq_, ok_
-
+from .test_basic import make_simple_cohort
 
 def test_strip_single_column_name():
     res = [_strip_column_name(col) for col in ['PD-L1', 'PD L1', 'PD L1_']]
@@ -39,3 +39,30 @@ def test_strip_column_names():
     df3 = df.rename(columns=strip_column_names(
         df.columns, keep_paren_contents=False))
     ok_((df3.columns == df.columns).all())
+
+def test_as_dataframe():
+    cohort = make_simple_cohort()
+    df_hello = pd.DataFrame({'one': pd.Series([1., 2., 3.], index=['a', 'b', 'c']),
+         'two': pd.Series([1., 2., 3., 4.], index=['a', 'b', 'c', 'd']),
+         'PD L1 (val)': pd.Series([1., 2., 3., 4.], index=['a', 'b', 'c', 'd']),
+         'PD L1 (>1)': pd.Series([0., 1., 1., 1.], index=['a', 'b', 'c', 'd']),
+         'the_id': ['1', '5', '7'],
+         })
+    def load_df():
+        return df_hello
+    df_loader = DataFrameLoader("hello", load_df, join_on="the_id")
+    cohort.df_loaders = [df_loader]
+
+    # test that column names haven't changed
+    df = cohort.as_dataframe(join_with="hello")
+    # column names should match those in df_hello
+    ok_((df.columns == df_hello.columns).all())
+
+    # test behavior with rename_cols=True
+    df2 = cohort.as_dataframe(rename_cols=True)
+    eq_(df2.columns, ['one','two','pd_l1_val','pd_l1_gt_1','the_id'])
+
+    # test behavior with keep_paren_contents=False
+    df3 = cohort.as_dataframe(rename_cols=True, keep_paren_contents=False)
+    # column names should match those in df_hello
+    ok_((df3.columns == df_hello.columns).all())

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -13,17 +13,17 @@
 # limitations under the License.
 
 import pandas as pd
-from cohorts.utils import clean_column_names, _clean_column_name
+from cohorts.utils import strip_column_names, _strip_column_name
 
 from nose.tools import eq_, ok_
 
 
-def test_clean_column_name():
-    res = [_clean_column_name(col) for col in ['PD-L1', 'PD L1', 'PD L1_']]
+def test_strip_single_column_name():
+    res = [_strip_column_name(col) for col in ['PD-L1', 'PD L1', 'PD L1_']]
     eq_(res, ['pd_l1', 'pd_l1', 'pd_l1'])
 
 
-def test_column_names():
+def test_strip_column_names():
     d = {'one': pd.Series([1., 2., 3.], index=['a', 'b', 'c']),
          'two': pd.Series([1., 2., 3., 4.], index=['a', 'b', 'c', 'd']),
          'PD L1 (val)': pd.Series([1., 2., 3., 4.], index=['a', 'b', 'c', 'd']),
@@ -32,10 +32,10 @@ def test_column_names():
     df = pd.DataFrame(d)
 
     # should not error & should rename columns
-    df2 = df.rename(columns=clean_column_names(df.columns))
+    df2 = df.rename(columns=strip_column_names(df.columns))
     ok_((df2.columns != df.columns).any())
 
     # should not rename columns -- should error
-    df3 = df.rename(columns=clean_column_names(
+    df3 = df.rename(columns=strip_column_names(
         df.columns, keep_paren_contents=False))
     ok_((df3.columns == df.columns).all())

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -43,7 +43,15 @@ def test_strip_column_names():
     ok_((df3.columns == df.columns).all())
 
 
-def test_as_dataframe():
+def test_as_dataframe_generic():
+    cohort = prep_test_cohort()
+    # test that column names haven't changed
+    df = cohort.as_dataframe(join_with="hello")
+    # column names should match those in df_hello
+    ok_([col in df_hello.columns for col in df.columns])
+
+
+def prep_test_cohort():
     cohort = make_simple_cohort()
     df_hello = pd.DataFrame({
         'one': [1., 2., 3.],
@@ -57,17 +65,18 @@ def test_as_dataframe():
         return df_hello
     df_loader = DataFrameLoader("hello", load_df, join_on="the_id")
     cohort.df_loaders = [df_loader]
+    return cohort
 
-    # test that column names haven't changed
-    df = cohort.as_dataframe(join_with="hello")
-    # column names should match those in df_hello
-    ok_((df.columns == df_hello.columns).all())
-
+def test_as_dataframe_rename():
+    cohort = prep_test_cohort()
     # test behavior with rename_cols=True
-    df2 = cohort.as_dataframe(rename_cols=True)
+    df2 = cohort.as_dataframe(rename_cols=True, join_with='hello')
     eq_(df2.columns, ['one', 'two', 'pd_l1_val', 'pd_l1_gt_1', 'the_id'])
 
+
+def test_as_dataframe_drop_parens():
+    cohort = prep_test_cohort()
     # test behavior with keep_paren_contents=False
-    df3 = cohort.as_dataframe(rename_cols=True, keep_paren_contents=False)
+    df3 = cohort.as_dataframe(rename_cols=True, keep_paren_contents=False, join_with='hello')
     # column names should match those in df_hello
     ok_((df3.columns == df_hello.columns).all())

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,0 +1,39 @@
+# Copyright (c) 2016. Mount Sinai School of Medicine
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pandas as pd
+from cohorts.utils import clean_column_names, _clean_column_name
+
+from nose.tools import raises, eq_, ok_
+
+def test_clean_column_name():
+    res = [_clean_column_name(col) for col in ['PD-L1','PD L1','PD L1_']]
+    eq_(res, ['PD_L1','PD_L1','PD_L1'])
+
+def test_column_names():
+    d = {'one' : pd.Series([1., 2., 3.], index=['a', 'b', 'c']),
+      'two' : pd.Series([1., 2., 3., 4.], index=['a', 'b', 'c', 'd']),
+      'PD L1 (value)': pd.Series([1., 2., 3., 4.], index=['a', 'b', 'c', 'd']),
+      'PD L1 (>1)': pd.Series([0., 1., 1., 0.], index=['a', 'b', 'c', 'd']),
+      }
+    d = pd.DataFrame(d)
+    ## should not error & should rename columns
+    d2 = d.rename(columns = clean_column_names(d.columns))
+    ok_(d2.columns != d.columns)
+
+    ## should not rename columns -- should error
+    d3 = d.rename(columns = clean_column_names(d.columns, keep_parens = False))
+    eq_(d3.columns, d.columns)
+
+

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -30,10 +30,10 @@ def test_column_names():
     d = pd.DataFrame(d)
     ## should not error & should rename columns
     d2 = d.rename(columns = clean_column_names(d.columns))
-    ok_(d2.columns != d.columns)
+    ok_((d2.columns != d.columns).any())
 
     ## should not rename columns -- should error
     d3 = d.rename(columns = clean_column_names(d.columns, keep_parens = False))
-    eq_(d3.columns, d.columns)
+    ok_((d3.columns == d.columns).all())
 
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -15,6 +15,7 @@
 import pandas as pd
 from cohorts.utils import strip_column_names, _strip_column_name
 from cohorts import DataFrameLoader
+import warnings
 
 from nose.tools import eq_, ok_
 from .test_basic import make_simple_cohort
@@ -74,20 +75,20 @@ def test_as_dataframe_generic():
 
 def test_as_dataframe_rename():
     df_hello, cohort = prep_test_cohort()
-    # test behavior with rename_cols=True
-    df = cohort.as_dataframe(rename_cols=True, join_with='hello')
-    expected = Set(['one', 'two', 'pd_l1_val', 'pd_l1_gt_1', 'the_id'])
+    # test behavior with rename_cols=True. should raise a warning
+    with warnings.catch_warnings(record=True) as w:
+        df = cohort.as_dataframe(rename_cols=True, join_with='hello')
+    expected = Set(df_hello.columns)
     returned = Set(df.columns)
     print('Expected:', expected)
     print('Returned:', returned)
     ok_(expected.issubset(returned))
 
-
 def test_as_dataframe_drop_parens():
     df_hello, cohort = prep_test_cohort()
     # test behavior with keep_paren_contents=False
-    df = cohort.as_dataframe(rename_cols=True, keep_paren_contents=False, join_with='hello')
-    # column names should match those in df_hello
+    with warnings.catch_warnings(record=True) as w:
+        df = cohort.as_dataframe(rename_cols=True, keep_paren_contents=False, join_with='hello')
     expected = Set(df_hello.columns)
     returned = Set(df.columns)
     print('Expected:', expected)


### PR DESCRIPTION
Added a function `strip_column_names` that converts column names to patsy-friendly strings.

**Note** the name has changed to `strip_column_names` (it was `clean_column_names`) in an attempt to be less confusing. Clean could be confused with presentation-ready column names.
## Example usage :

```
from cohorts.utils import strip_column_names
cohort = cohorts.init_cohort(...)
d = cohort.get_dataframe()
d = d.rename(columns = strip_column_names(d.columns))
```

You can now also do the above in one step, as:

```
d = cohort.get_dataframe(rename_cols=True)
```

  (this latter functionality is `off` by default, so the current behavior is unchanged)
## Behavior

In both cases, the function modifies column names as : 

```
1. convert meaningful punctuation to str (e.g. `<` becomes `lt`)
2. (optionally - not default) remove text within parens
3. convert remaining punctuation/whitespace -> _
4. change to lowercase
5. strip leading & trailing punctuation
```

It will additionally check for uniqueness of stripped column names, and will return original values if the revised names are non-unique.
## Examples

Some examples of how this maps from old to new names:

```
{'2-factor score': '2_factor_score',
 '5-factor score': '5_factor_score',
 'Age': 'age',
 'Albumin < 4': 'albumin_lt_4',
 'Alive Status': 'alive_status',
 'Baseline neutrophil to lymphocyte ratio': 'baseline_neutrophil_to_lymphocyte_ratio',
 'Best Response RECIST 1.1': 'best_response_recist_1_1',
 'Best response mRECIST': 'best_response_mrecist',
 'Date of Best Response': 'date_of_best_response',
 'ECOG >0': 'ecog_gt_0',
 'Hb < 10': 'hb_lt_10',
 'Liver Mets': 'liver_mets',
 'Number of Lines of Therapy': 'number_of_lines_of_therapy',
 'OS in days': 'os_in_days',
 'Ongoing Responder RECIST 1.1': 'ongoing_responder_recist_1_1',
 'PD-L1': 'pd_l1',
 'PFS (RECIST 1.1) in days': 'pfs_recist_1_1_in_days',
 'PFS (mRECIST 1.1) in days': 'pfs_mrecist_1_1_in_days',
 'Pack Years': 'pack_years',
 'Prior BCG': 'prior_bcg',
 'Response Mixed or Homogenous': 'response_mixed_or_homogenous',
 'Sequence Path': 'sequence_path',
```
