### PR TITLE
Fix minor bug in summarize_provenance

### DIFF
--- a/cohorts/load.py
+++ b/cohorts/load.py
@@ -1298,7 +1298,7 @@ def compare_provenance(
     Number of discrepancies (0: None)
     """
     ## if either this or other items is null, return 0
-    if (!this_items or !other_items):
+    if (not this_provenance or not other_provenance):
         return 0
     
     this_items = set(this_provenance.items())

--- a/cohorts/load.py
+++ b/cohorts/load.py
@@ -1297,6 +1297,10 @@ def compare_provenance(
     -----------
     Number of discrepancies (0: None)
     """
+    ## if either this or other items is null, return 0
+    if (!this_items or !other_items):
+        return 0
+    
     this_items = set(this_provenance.items())
     other_items = set(other_provenance.items())
 

--- a/test/test_provenance.py
+++ b/test/test_provenance.py
@@ -17,6 +17,7 @@ from __future__ import print_function
 from nose.tools import eq_, ok_
 import pandas as pd
 from os import path
+import os
 import cohorts
 import warnings
 
@@ -117,6 +118,11 @@ def test_summarize_provenance():
             warnings.simplefilter("always")
             ok_(not cohort.summarize_provenance_per_cache()[cache_name])
             ok_(len(w)>0)
+
+        ## now test whether deleting second patient's provenance file causes an error 
+        os.remove(provenance_path)
+        summary = cohort.summarize_provenance()
+
 
     finally:
         if cohort is not None:

--- a/test/test_provenance.py
+++ b/test/test_provenance.py
@@ -18,6 +18,7 @@ from nose.tools import eq_, ok_
 import pandas as pd
 from os import path
 import os
+from shutil import rmtree
 import cohorts
 import warnings
 
@@ -119,8 +120,10 @@ def test_summarize_provenance():
             ok_(not cohort.summarize_provenance_per_cache()[cache_name])
             ok_(len(w)>0)
 
-        ## now test whether deleting second patient's provenance file causes an error 
-        os.remove(provenance_path)
+        ## now test whether deleting contents of cache_dir causes an error 
+        dirlist = [ f for f in os.listdir(cache_dir) ]
+        for dir in dirlist:
+            rmtree(path.join(cache_dir, dir))
         summary = cohort.summarize_provenance()
 
 

--- a/test/test_provenance.py
+++ b/test/test_provenance.py
@@ -121,12 +121,10 @@ def test_summarize_provenance():
             ok_(len(w)>0)
 
         ## now test whether deleting contents of cache_dir causes an error 
-        dirlist = [ f for f in os.listdir(cache_dir) ]
+        dirlist = [f for f in os.listdir(cache_dir)]
         for dir in dirlist:
             rmtree(path.join(cache_dir, dir))
         summary = cohort.summarize_provenance()
-
-
     finally:
         if cohort is not None:
             cohort.clear_caches()


### PR DESCRIPTION
This should fix #92 - a minor bug causing summarize_provenance to break when the contents of a cache directory are empty.

For the record, also confirmed that test case recreates the current bug on master branch.

Here is the output from running that test case on `master` branch:

```
(env) jacquelineburos@jacki2:~/projects/cohorts$ nosetests .
................E./mnt/ssd0/projects/cohorts/cohorts/utils.py:136: UserWarning: Warning: strip_column_names (if run) would introduce duplicate names. Reverting column names to the original.
  warnings.warn(warn_str)
............
======================================================================
ERROR: test.test_provenance.test_summarize_provenance
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/mnt/ssd0/env/local/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/mnt/ssd0/projects/cohorts/test/test_provenance.py", line 127, in test_summarize_provenance
    summary = cohort.summarize_provenance()
  File "/mnt/ssd0/projects/cohorts/cohorts/load.py", line 1228, in summarize_provenance
    right_outer_diff = "In %s but not in %s" % (summary_provenance_name, cache)
  File "/mnt/ssd0/projects/cohorts/cohorts/load.py", line 1300, in compare_provenance
    this_items = set(this_provenance.items())
AttributeError: 'NoneType' object has no attribute 'items'
-------------------- >> begin captured stdout << ---------------------
{'dataframe_hash': 4928625243270084759, 'provenance_file_summary': None}
{u'cohorts': u'0+untagged.269.gf60938b.dirty', u'topiary': u'0.0.21', u'isovar': u'0.0.6', u'mhctools': u'0.2.3', u'pyensembl': u'0.9.3', u'scipy': u'0.17.1', u'varcode': u'0.4.15', u'numpy': u'1.11.1', u'pandas': '1.0.1'}


{u'cohorts': u'0+untagged.269.gf60938b.dirty', u'varcode': u'0.4.15', u'numpy': u'1.11.1', u'mhctools': u'0.2.3', u'pyensembl': u'0.9.3', u'scipy': u'0.17.1', u'topiary': u'0.0.21', u'isovar': u'0.0.6', u'pandas': u'1.0.1'}

--------------------- >> end captured stdout << ----------------------

----------------------------------------------------------------------
Ran 30 tests in 4.424s

FAILED (errors=1)
```
