### PR TITLE
Fix expressed_missense_snv_count for None filter_fn

### DIFF
--- a/cohorts/functions.py
+++ b/cohorts/functions.py
@@ -96,7 +96,7 @@ def neoantigen_count(row, cohort, filter_fn=None,
     return np.nan
 
 def expressed_missense_snv_count(row, cohort, **kwargs):
-    filter_fn = kwargs.pop("filter_fn")
+    filter_fn = kwargs.pop("filter_fn", None)
     def expressed_filter_fn(filterable_effect):
         if filter_fn is not None:
             return filter_fn(filterable_effect) and effect_expressed_filter(filterable_effect)

--- a/cohorts/functions.py
+++ b/cohorts/functions.py
@@ -95,13 +95,16 @@ def neoantigen_count(row, cohort, filter_fn=None,
         return count
     return np.nan
 
-def expressed_missense_snv_count(row, cohort, **kwargs):
-    filter_fn = kwargs.pop("filter_fn", None)
+def expressed_missense_snv_count(row, cohort, filter_fn=None,
+                                 normalized_per_mb=None):
+    filter_fn = first_not_none_param([filter_fn, cohort.filter_fn], no_filter)
+    normalized_per_mb = first_not_none_param([normalized_per_mb, cohort.normalized_per_mb], False)
     def expressed_filter_fn(filterable_effect):
         if filter_fn is not None:
             return filter_fn(filterable_effect) and effect_expressed_filter(filterable_effect)
         return effect_expressed_filter(filterable_effect)
-    return missense_snv_count(row, cohort, filter_fn=expressed_filter_fn, **kwargs)
+    return missense_snv_count(row, cohort, filter_fn=expressed_filter_fn,
+                              normalized_per_mb=normalized_per_mb)
 
 def expressed_neoantigen_count(row, cohort, **kwargs):
     return neoantigen_count(row, cohort, only_expressed=True, **kwargs)

--- a/cohorts/functions.py
+++ b/cohorts/functions.py
@@ -61,10 +61,9 @@ def missense_snv_count(row, cohort, filter_fn=None,
     normalized_per_mb = first_not_none_param([normalized_per_mb, cohort.normalized_per_mb], False)
     patient_id = row["patient_id"]
     def missense_filter_fn(filterable_effect):
-        if filter_fn is not None:
-            return (type(filterable_effect.effect) == Substitution and
-                    filter_fn(filterable_effect))
-        return type(filterable_effect.effect) == Substitution
+        assert filter_fn is not None, "filter_fn should never be None, but it is."
+        return (type(filterable_effect.effect) == Substitution and
+                filter_fn(filterable_effect))
     # This only loads one effect per variant.
     patient_missense_effects = cohort.load_effects(
         only_nonsynonymous=True,
@@ -100,9 +99,8 @@ def expressed_missense_snv_count(row, cohort, filter_fn=None,
     filter_fn = first_not_none_param([filter_fn, cohort.filter_fn], no_filter)
     normalized_per_mb = first_not_none_param([normalized_per_mb, cohort.normalized_per_mb], False)
     def expressed_filter_fn(filterable_effect):
-        if filter_fn is not None:
-            return filter_fn(filterable_effect) and effect_expressed_filter(filterable_effect)
-        return effect_expressed_filter(filterable_effect)
+        assert filter_fn is not None, "filter_fn should never be None, but it is."
+        return filter_fn(filterable_effect) and effect_expressed_filter(filterable_effect)
     return missense_snv_count(row, cohort, filter_fn=expressed_filter_fn,
                               normalized_per_mb=normalized_per_mb)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ pylint>=1.4.4
 scikit-bio==0.4.2
 isovar==0.0.6
 patsy>=0.4.1
+mock>=2.0.0

--- a/test/functions.py
+++ b/test/functions.py
@@ -15,6 +15,7 @@
 from cohorts.functions import (
     snv_count as cohorts_snv_count,
     missense_snv_count as cohorts_missense_snv_count,
+    expressed_missense_snv_count as cohorts_expressed_missense_snv_count,
     neoantigen_count as cohorts_neoantigen_count,
     expressed_neoantigen_count as cohorts_expressed_neoantigen_count
 )
@@ -24,17 +25,16 @@ from cohorts.functions import (
 # TODO: Tests should simply work with these options set to True.
 
 def snv_count(row, cohort, **kwargs):
-    return cohorts_snv_count(row, cohort, filter_fn=None,
-                             normalized_per_mb=False, **kwargs)
+    return cohorts_snv_count(row, cohort, normalized_per_mb=False, **kwargs)
 
 def missense_snv_count(row, cohort, **kwargs):
-    return cohorts_missense_snv_count(row, cohort, filter_fn=None,
-                                      normalized_per_mb=False, **kwargs)
+    return cohorts_missense_snv_count(row, cohort, normalized_per_mb=False, **kwargs)
 
 def neoantigen_count(row, cohort, **kwargs):
-    return cohorts_neoantigen_count(row, cohort, filter_fn=None,
-                                    normalized_per_mb=False, **kwargs)
+    return cohorts_neoantigen_count(row, cohort, normalized_per_mb=False, **kwargs)
+
+def expressed_missense_snv_count(row, cohort, **kwargs):
+    return cohorts_expressed_missense_snv_count(row, cohort, normalized_per_mb=False, **kwargs)
 
 def expressed_neoantigen_count(row, cohort, **kwargs):
-    return cohorts_expressed_neoantigen_count(row, cohort, filter_fn=None,
-                                              normalized_per_mb=False, **kwargs)
+    return cohorts_expressed_neoantigen_count(row, cohort, normalized_per_mb=False, **kwargs)


### PR DESCRIPTION
`expressed_missense_snv_count` is currently broken when no `filter_fn` arg is present. Fixes that.

@arahuja 

FYI @jburos
