### PR TITLE
Remove flier from boxplot on stripboxplot

### DIFF
--- a/cohorts/plot.py
+++ b/cohorts/plot.py
@@ -29,7 +29,8 @@ def stripboxplot(x, y, data, ax=None, **kwargs):
         x=x,
         y=y,
         data=data,
-        ax=ax
+        ax=ax, 
+        fliersize=0
     )
 
     return sb.stripplot(


### PR DESCRIPTION
This removes the outlier marker from `stripboxplot` since we plot each point anyways
