### PR TITLE
Return namedtuples in plot functions

### DIFF
--- a/cohorts/load.py
+++ b/cohorts/load.py
@@ -1076,18 +1076,18 @@ class Cohort(Collection):
         return roc_curve_plot(df, plot_col, "benefit", bootstrap_samples, ax=ax)
 
     def plot_benefit(self, on, col=None, benefit_col="benefit", ax=None,
-                     mw_alternative="two-sided", **kwargs):
+                     alternative="two-sided", **kwargs):
         """Plot a comparison of benefit/response in the cohort on a given variable
         """
         return self.plot_boolean(on=on,
                                  boolean_col=benefit_col,
                                  col=col,
-                                 mw_alternative=mw_alternative,
+                                 alternative=alternative,
                                  ax=ax,
                                  **kwargs)
 
     def plot_boolean(self, on, boolean_col, col=None, ax=None,
-                     mw_alternative="two-sided", **kwargs):
+                     alternative="two-sided", **kwargs):
         """Plot a comparison of `boolean_col` in the cohort on a given variable via
         `on` or `col`.
 
@@ -1103,8 +1103,8 @@ class Cohort(Collection):
             See `cohort.load.as_dataframe`
         col : str, optional
             If specified, store the result of `on`. See `cohort.load.as_dataframe`
-        mw_alternative : str, optional
-            Choose the sidedness of the mannwhitneyu test.
+        alternative : str, optional
+            Choose the sidedness of the mannwhitneyu or Fisher's Exact test.
 
         Returns
         -------
@@ -1119,13 +1119,15 @@ class Cohort(Collection):
             results = fishers_exact_plot(
                 data=df,
                 condition1=boolean_col,
-                condition2=plot_col)
+                condition2=plot_col,
+                alternative=alternative,
+                ax=ax)
         else:
             results = mann_whitney_plot(
                 data=df,
                 condition=boolean_col,
                 distribution=plot_col,
-                alternative=mw_alternative,
+                alternative=alternative,
                 ax=ax)
         return results
 

--- a/cohorts/plot.py
+++ b/cohorts/plot.py
@@ -30,7 +30,7 @@ def stripboxplot(x, y, data, ax=None, **kwargs):
         x=x,
         y=y,
         data=data,
-        ax=ax, 
+        ax=ax,
         fliersize=0
     )
 
@@ -44,7 +44,7 @@ def stripboxplot(x, y, data, ax=None, **kwargs):
         **kwargs
     )
 
-def sided_str_from_alternative(alternative):
+def sided_str_from_alternative(alternative, condition):
     if alternative is None:
         raise ValueError("Must pick an alternative")
     if alternative == "two-sided":
@@ -65,7 +65,7 @@ def fishers_exact_plot(data, condition1, condition2, ax=None, alternative="two-s
         Dataframe to retrieve information from
 
     condition1: str
-        First binary column compare
+        First binary column to compare (and used for test sidedness)
 
     condition2: str
         Second binary column to compare
@@ -86,7 +86,7 @@ def fishers_exact_plot(data, condition1, condition2, ax=None, alternative="two-s
     count_table = pd.crosstab(data[condition1], data[condition2])
     print(count_table)
     oddsratio, pvalue = fisher_exact(count_table, alternative=alternative)
-    sided_str = sided_str_from_alternative(alternative)
+    sided_str = sided_str_from_alternative(alternative, condition=condition1)
     print("Fisher's Exact Test: OR: {}, p-value={} ({})".format(oddsratio, pvalue, sided_str))
     return FishersExactResults(oddsratio=oddsratio,
                                pvalue=pvalue,
@@ -145,7 +145,7 @@ def mann_whitney_plot(data, condition, distribution, ax=None,
         alternative=alternative
     )
 
-    sided_str = sided_str_from_alternative(alternative)
+    sided_str = sided_str_from_alternative(alternative, condition)
     print("Mann-Whitney test: U={}, p-value={} ({})".format(U, pvalue, sided_str))
     return MannWhitneyResults(U=U,
                               pvalue=pvalue,

--- a/cohorts/plot.py
+++ b/cohorts/plot.py
@@ -86,7 +86,9 @@ def fishers_exact_plot(data, condition1, condition2, ax=None, alternative="two-s
     count_table = pd.crosstab(data[condition1], data[condition2])
     print(count_table)
     oddsratio, pvalue = fisher_exact(count_table, alternative=alternative)
-    sided_str = sided_str_from_alternative(alternative, condition=condition1)
+    if alternative != "two-sided":
+        raise ValueError("We need to better understand the one-sided Fisher's Exact test")
+    sided_str = "two-sided"
     print("Fisher's Exact Test: OR: {}, p-value={} ({})".format(oddsratio, pvalue, sided_str))
     return FishersExactResults(oddsratio=oddsratio,
                                pvalue=pvalue,

--- a/cohorts/plot.py
+++ b/cohorts/plot.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from __future__ import print_function
+from collections import namedtuple
 
 from scipy.stats import mannwhitneyu, fisher_exact
 import seaborn as sb
@@ -43,7 +44,18 @@ def stripboxplot(x, y, data, ax=None, **kwargs):
         **kwargs
     )
 
-def fishers_exact_plot(data, condition1, condition2, ax=None):
+def sided_str_from_alternative(alternative):
+    if alternative is None:
+        raise ValueError("Must pick an alternative")
+    if alternative == "two-sided":
+        return alternative
+    # alternative hypothesis: condition is 'less' or 'greater' than no-condition
+    op_str = ">" if alternative == "greater" else "<"
+    return "one-sided: %s %s not %s" % (condition, op_str, condition)
+
+FishersExactResults = namedtuple("FishersExactResults", ["oddsratio", "pvalue", "sided_str", "plot"])
+
+def fishers_exact_plot(data, condition1, condition2, ax=None, alternative="two-sided"):
     """
     Perform a Fisher's exact test to compare to binary columns
 
@@ -60,6 +72,10 @@ def fishers_exact_plot(data, condition1, condition2, ax=None):
 
     ax : Axes, default None
         Axes to plot on
+
+    alternative:
+        Specify the sidedness of the test: "two-sided", "less"
+        or "greater"
     """
     plot = sb.barplot(
         x=condition1,
@@ -69,9 +85,15 @@ def fishers_exact_plot(data, condition1, condition2, ax=None):
     )
     count_table = pd.crosstab(data[condition1], data[condition2])
     print(count_table)
-    oddsratio, pvalue = fisher_exact(count_table)
-    print("Fisher's Exact Test: OR: {}, p-value={}".format(oddsratio, pvalue))
-    return (oddsratio, pvalue, plot)
+    oddsratio, pvalue = fisher_exact(count_table, alternative=alternative)
+    sided_str = sided_str_from_alternative(alternative)
+    print("Fisher's Exact Test: OR: {}, p-value={} ({})".format(oddsratio, pvalue, sided_str))
+    return FishersExactResults(oddsratio=oddsratio,
+                               pvalue=pvalue,
+                               sided_str=sided_str,
+                               plot=plot)
+
+MannWhitneyResults = namedtuple("MannWhitneyResults", ["U", "pvalue", "sided_str", "with_condition_series", "without_condition_series", "plot"])
 
 def mann_whitney_plot(data, condition, distribution, ax=None,
                       condition_value=None, alternative="two-sided",
@@ -123,16 +145,14 @@ def mann_whitney_plot(data, condition, distribution, ax=None,
         alternative=alternative
     )
 
-    if alternative is None:
-        raise ValueError("Must pick a mannwhitneyu alternative")
-    if alternative == "two-sided":
-        sided_str = alternative
-    else:
-        # alternative hypothesis: condition is 'less' or 'greater' than no-condition
-        op_str = ">" if alternative == "greater" else "<"
-        sided_str = "one-sided: %s %s not %s" % (condition, op_str, condition)
+    sided_str = sided_str_from_alternative(alternative)
     print("Mann-Whitney test: U={}, p-value={} ({})".format(U, pvalue, sided_str))
-    return (U, pvalue, plot)
+    return MannWhitneyResults(U=U,
+                              pvalue=pvalue,
+                              sided_str=sided_str,
+                              with_condition_series=data[condition_mask][distribution],
+                              without_condition_series=data[~condition_mask][distribution],
+                              plot=plot)
 
 def roc_curve_plot(data, value_column, outcome_column, bootstrap_samples=100, ax=None):
     """Create a ROC curve and compute the bootstrap AUC for the given variable and outcome

--- a/test/test_plot.py
+++ b/test/test_plot.py
@@ -22,13 +22,13 @@ from cohorts.plot import mann_whitney_plot
 def test_mann_whitney():
     data = pd.DataFrame({"distribution": range(1, 7),
                          "condition": [True, False] * 3})
-    U_default, p_default, _ = mann_whitney_plot(data, "condition", "distribution",
-                                                skip_plot=True)
-    U_two, p_two, _ = mann_whitney_plot(data, "condition", "distribution",
-                                        alternative="two-sided", skip_plot=True)
-    U_less, p_less, _ = mann_whitney_plot(data, "condition", "distribution",
-                                          alternative="less", skip_plot=True)
-    U_greater, p_greater, _ = mann_whitney_plot(data, "condition", "distribution",
-                                                alternative="greater", skip_plot=True)
+    U_default, p_default, _, _, _, _ = mann_whitney_plot(
+        data, "condition", "distribution", skip_plot=True)
+    U_two, p_two, _, _, _, _ = mann_whitney_plot(
+        data, "condition", "distribution", alternative="two-sided", skip_plot=True)
+    U_less, p_less, _, _, _, _ = mann_whitney_plot(
+        data, "condition", "distribution", alternative="less", skip_plot=True)
+    U_greater, p_greater, _, _, _, _ = mann_whitney_plot(
+        data, "condition", "distribution", alternative="greater", skip_plot=True)
     eq_(p_default, p_two)
     ok_((p_default == p_less * 2) or (p_default == p_greater * 2))


### PR DESCRIPTION
Main purpose: return more information for Mann Whitney, so I can easily compare the benefit vs. no-benefit distributions.

Also: use a customizable "alternative" for two-sided vs. one-sided (won't matter in the default cause, since `fishers_exact` defaults to `two-sided`).

@arahuja 
