### PR TITLE
Fix survival plots for non-threshold conditions

### DIFF
--- a/cohorts/load.py
+++ b/cohorts/load.py
@@ -1182,7 +1182,7 @@ class Cohort(Collection):
                 ax=ax)
         return results
 
-    def plot_survival(self, on, col=None, how="os", ax=None,
+    def plot_survival(self, on, col=None, how="os", survival_units="Days", ax=None, ci_show=False,
                       threshold=None, **kwargs):
         """Plot a Kaplan Meier survival curve by splitting the cohort into two groups
         Parameters
@@ -1193,6 +1193,8 @@ class Cohort(Collection):
             If specified, store the result of `on`. See `cohort.load.as_dataframe`
         how : {"os", "pfs"}, optional
             Whether to plot OS (overall survival) or PFS (progression free survival)
+        survival_units : str
+            Unit of time for the survival measure, i.e. Days or Months
         threshold : int or "median", optional
             Threshold of `col` on which to split the cohort
         """
@@ -1206,12 +1208,13 @@ class Cohort(Collection):
         results = plot_kmf(
             df=df,
             condition_col=plot_col,
-            xlabel="Days",
+            xlabel=survival_units,
             ylabel="Overall Survival (%)" if how == "os" else "Progression-Free Survival (%)",
             censor_col="deceased" if how == "os" else "progressed_or_deceased",
             survival_col=how,
             threshold=threshold if threshold is not None else default_threshold,
-            ax=ax)
+            ax=ax,
+            ci_show=ci_show)
         return results
 
     def plot_joint(self, on, on_two=None, **kwargs):

--- a/cohorts/load.py
+++ b/cohorts/load.py
@@ -1195,6 +1195,8 @@ class Cohort(Collection):
             Whether to plot OS (overall survival) or PFS (progression free survival)
         survival_units : str
             Unit of time for the survival measure, i.e. Days or Months
+        ci_show : bool
+            Display the confidence interval around the survival curve
         threshold : int or "median", optional
             Threshold of `col` on which to split the cohort
         """

--- a/cohorts/survival.py
+++ b/cohorts/survival.py
@@ -66,8 +66,8 @@ def plot_kmf(df,
         label_with_condition = "%s > %s" % (condition_col, label_suffix)
     else:
         condition = df[condition_col]
-        label_with_condition = "{}".format(condition_col)
-        label_no_condition = ""
+        label_with_condition = "= {}".format(condition_col)
+        label_no_condition = "¬ {}".format(condition_col)
 
     df_with_condition = df[condition]
     df_no_condition = df[~condition]

--- a/cohorts/survival.py
+++ b/cohorts/survival.py
@@ -28,6 +28,7 @@ def plot_kmf(df,
              xlabel=None,
              ylabel=None,
              ax=None,
+             ci_show=False,
              print_as_title=False):
     """
     Plot survival curves by splitting the dataset into two groups based on
@@ -65,7 +66,8 @@ def plot_kmf(df,
         label_with_condition = "%s > %s" % (condition_col, label_suffix)
     else:
         condition = df[condition_col]
-        label = "{}".format(condition_col)
+        label_with_condition = "{}".format(condition_col)
+        label_no_condition = ""
 
     df_with_condition = df[condition]
     df_no_condition = df[~condition]
@@ -77,12 +79,12 @@ def plot_kmf(df,
 
     kmf.fit(survival_no_condition, event_no_condition, label=(label_no_condition))
     if ax:
-        kmf.plot(ax=ax, show_censors=True, ci_show=False)
+        kmf.plot(ax=ax, show_censors=True, ci_show=ci_show)
     else:
-        ax = kmf.plot(show_censors=True, ci_show=False)
+        ax = kmf.plot(show_censors=True, ci_show=ci_show)
 
     kmf.fit(survival_with_condition, event_with_condition, label=(label_with_condition))
-    plot = kmf.plot(ax=ax, show_censors=True, ci_show=False)
+    plot = kmf.plot(ax=ax, show_censors=True, ci_show=ci_show)
 
     # Set the y-axis to range 0 to 1
     ax.set_ylim(0, 1)


### PR DESCRIPTION
Two changes here:
- labeling of the lines was broken when the condition passed was a binary series and not a comparison
  - added some configuration options while I was in there, allow the xlabel to be configurable (in case it needs to be months instead of days) and added a config option for `ci_show` out of curiosity.
