### PR TITLE
Pass stat_func through jointplot

### DIFF
--- a/cohorts/load.py
+++ b/cohorts/load.py
@@ -1220,15 +1220,17 @@ class Cohort(Collection):
             ci_show=ci_show)
         return results
 
-    def plot_joint(self, on, on_two=None, plot_type="jointplot", stat_func=pearsonr, **kwargs):
+    def plot_joint(self, on, on_two=None, x_col=None, plot_type="jointplot", stat_func=pearsonr, **kwargs):
         """Plot the correlation between two variables.
 
         Parameters
         ----------
-        on : function or list or map of functions
+        on : function or list or dict of functions
             See `cohort.load.as_dataframe`
         on_two : function, optional
             Can specify the second function here rather than creating a list.
+        x_col : str, optional
+            If `on` is a dict, this guarantees we have the expected ordering.
         plot_type : str, optional
             Specify "jointplot" or "boxplot".
         stat_func : function, optional.
@@ -1241,8 +1243,14 @@ class Cohort(Collection):
         plot_cols, df = self.as_dataframe(on, **kwargs)
         for plot_col in plot_cols:
             df = filter_not_null(df, plot_col)
-        x_col = plot_cols[0]
-        y_col = plot_cols[1]
+        if x_col is None:
+            x_col = plot_cols[0]
+            y_col = plot_cols[1]
+        else:
+            if x_col == plot_cols[0]:
+                y_col = plot_cols[1]
+            else:
+                y_col = plot_cols[0]
         series_x = df[x_col]
         series_y = df[y_col]
         coeff, p_value = stat_func(series_x, series_y)

--- a/cohorts/load.py
+++ b/cohorts/load.py
@@ -43,7 +43,7 @@ from scipy.stats import pearsonr
 
 from .utils import strip_column_names as _strip_column_names
 from .survival import plot_kmf
-from .plot import mann_whitney_plot, fishers_exact_plot, roc_curve_plot
+from .plot import mann_whitney_plot, fishers_exact_plot, roc_curve_plot, stripboxplot, CorrelationResults
 from .collection import Collection
 from .varcode_utils import (filter_variants, filter_effects,
                             filter_neoantigens, filter_polyphen)
@@ -1220,8 +1220,8 @@ class Cohort(Collection):
             ci_show=ci_show)
         return results
 
-    def plot_joint(self, on, on_two=None, stat_func=pearsonr, **kwargs):
-        """Plot a jointplot.
+    def plot_joint(self, on, on_two=None, plot_type="jointplot", stat_func=pearsonr, **kwargs):
+        """Plot the correlation between two variables.
 
         Parameters
         ----------
@@ -1229,14 +1229,29 @@ class Cohort(Collection):
             See `cohort.load.as_dataframe`
         on_two : function, optional
             Can specify the second function here rather than creating a list.
+        plot_type : str, optional
+            Specify "jointplot" or "boxplot".
+        stat_func : function, optional.
+            Specify which function to use for the statistical test.
         """
+        if plot_type not in ["boxplot", "jointplot"]:
+            raise ValueError("Invalid plot_type %s" % plot_type)
         if on_two is not None:
             on = [on, on_two]
         plot_cols, df = self.as_dataframe(on, **kwargs)
         for plot_col in plot_cols:
             df = filter_not_null(df, plot_col)
-        p = sb.jointplot(data=df, x=plot_cols[0], y=plot_cols[1], stat_func=stat_func)
-        return p
+        x_col = plot_cols[0]
+        y_col = plot_cols[1]
+        series_x = df[x_col]
+        series_y = df[y_col]
+        coeff, p_value = stat_func(series_x, series_y)
+        if plot_type == "jointplot":
+            plot = sb.jointplot(data=df, x=x_col, y=y_col, stat_func=stat_func)
+        else:
+            plot = stripboxplot(data=df, x=x_col, y=y_col)
+        return CorrelationResults(coeff=coeff, p_value=p_value, stat_func=stat_func,
+                                  series_x=series_x, series_y=series_y, plot=plot)
 
     def _list_patient_ids(self):
         """ Utility function to return a list of patient ids in the Cohort

--- a/cohorts/load.py
+++ b/cohorts/load.py
@@ -1220,7 +1220,7 @@ class Cohort(Collection):
             ci_show=ci_show)
         return results
 
-    def plot_joint(self, on, on_two=None, x_col=None, plot_type="jointplot", stat_func=pearsonr, jointplot_kwargs={}, **kwargs):
+    def plot_joint(self, on, on_two=None, x_col=None, plot_type="jointplot", stat_func=pearsonr, show_stat_func=True, jointplot_kwargs={}, **kwargs):
         """Plot the correlation between two variables.
 
         Parameters
@@ -1235,6 +1235,8 @@ class Cohort(Collection):
             Specify "jointplot" or "boxplot".
         stat_func : function, optional.
             Specify which function to use for the statistical test.
+        show_stat_func : bool, optional
+            Whether or not to show the stat_func result in the plot itself.
         jointplot_kwargs : dict, optional
             kwargs to pass through to seaborn.jointplot.
         """
@@ -1257,7 +1259,8 @@ class Cohort(Collection):
         series_y = df[y_col]
         coeff, p_value = stat_func(series_x, series_y)
         if plot_type == "jointplot":
-            plot = sb.jointplot(data=df, x=x_col, y=y_col, stat_func=stat_func,
+            plot = sb.jointplot(data=df, x=x_col, y=y_col,
+                                stat_func=stat_func if show_stat_func else None,
                                 **jointplot_kwargs)
         else:
             plot = stripboxplot(data=df, x=x_col, y=y_col)

--- a/cohorts/load.py
+++ b/cohorts/load.py
@@ -1220,7 +1220,7 @@ class Cohort(Collection):
             ci_show=ci_show)
         return results
 
-    def plot_joint(self, on, on_two=None, x_col=None, plot_type="jointplot", stat_func=pearsonr, **kwargs):
+    def plot_joint(self, on, on_two=None, x_col=None, plot_type="jointplot", stat_func=pearsonr, jointplot_kwargs={}, **kwargs):
         """Plot the correlation between two variables.
 
         Parameters
@@ -1235,6 +1235,8 @@ class Cohort(Collection):
             Specify "jointplot" or "boxplot".
         stat_func : function, optional.
             Specify which function to use for the statistical test.
+        jointplot_kwargs : dict, optional
+            kwargs to pass through to seaborn.jointplot.
         """
         if plot_type not in ["boxplot", "jointplot"]:
             raise ValueError("Invalid plot_type %s" % plot_type)
@@ -1255,7 +1257,8 @@ class Cohort(Collection):
         series_y = df[y_col]
         coeff, p_value = stat_func(series_x, series_y)
         if plot_type == "jointplot":
-            plot = sb.jointplot(data=df, x=x_col, y=y_col, stat_func=stat_func)
+            plot = sb.jointplot(data=df, x=x_col, y=y_col, stat_func=stat_func,
+                                **jointplot_kwargs)
         else:
             plot = stripboxplot(data=df, x=x_col, y=y_col)
         return CorrelationResults(coeff=coeff, p_value=p_value, stat_func=stat_func,

--- a/cohorts/load.py
+++ b/cohorts/load.py
@@ -39,6 +39,7 @@ from topiary import predict_epitopes_from_variants, epitopes_to_dataframe
 from topiary.sequence_helpers import contains_mutant_residues
 from isovar.protein_sequence import variants_to_protein_sequences_dataframe
 from pysam import AlignmentFile
+from scipy.stats import pearsonr
 
 from .utils import strip_column_names as _strip_column_names
 from .survival import plot_kmf
@@ -1219,7 +1220,7 @@ class Cohort(Collection):
             ci_show=ci_show)
         return results
 
-    def plot_joint(self, on, on_two=None, **kwargs):
+    def plot_joint(self, on, on_two=None, stat_func=pearsonr, **kwargs):
         """Plot a jointplot.
 
         Parameters
@@ -1234,7 +1235,7 @@ class Cohort(Collection):
         plot_cols, df = self.as_dataframe(on, **kwargs)
         for plot_col in plot_cols:
             df = filter_not_null(df, plot_col)
-        p = sb.jointplot(data=df, x=plot_cols[0], y=plot_cols[1])
+        p = sb.jointplot(data=df, x=plot_cols[0], y=plot_cols[1], stat_func=stat_func)
         return p
 
     def _list_patient_ids(self):

--- a/cohorts/model.py
+++ b/cohorts/model.py
@@ -57,15 +57,15 @@ def bootstrap_auc(df, col, pred_col, n_bootstrap=1000):
         scores[i] = roc_auc_score(sampled_pred, sampled_counts)
     return scores
 
-def cohort_bootstrap_auc(cohort, func, pred_col="is_benefit", n_bootstrap=1000):
-    col, df = cohort.as_dataframe(func)
+def cohort_bootstrap_auc(cohort, func, pred_col="is_benefit", n_bootstrap=1000, **kwargs):
+    col, df = cohort.as_dataframe(func, **kwargs)
     return bootstrap_auc(df=df,
                          col=col,
                          pred_col=pred_col,
                          n_bootstrap=n_bootstrap)
 
-def cohort_mean_bootstrap_auc(cohort, func, pred_col="is_benefit", n_bootstrap=1000):
-    return cohort_bootstrap_auc(cohort, func, pred_col, n_bootstrap).mean()
+def cohort_mean_bootstrap_auc(cohort, func, pred_col="is_benefit", n_bootstrap=1000, **kwargs):
+    return cohort_bootstrap_auc(cohort, func, pred_col, n_bootstrap, **kwargs).mean()
 
 def coxph_model(formula, data, time_col, event_col, **kwargs):
     # pylint: disable=no-member

--- a/cohorts/plot.py
+++ b/cohorts/plot.py
@@ -248,6 +248,14 @@ def mann_whitney_plot(data,
                               without_condition_series=data[~condition_mask][distribution],
                               plot=plot)
 
+class CorrelationResults(namedtuple("CorrelationResults", ["coeff", "p_value", "stat_func", "series_x", "series_y", "plot"])):
+    def __str__(self):
+        return "CorrelationResults(coeff=%s, p_value=%s, stat_func=%s)" % (
+            self.coeff, self.p_value, self.stat_func.__name__)
+
+    def __repr__(self):
+        return self.__str__()
+
 def roc_curve_plot(data, value_column, outcome_column, bootstrap_samples=100, ax=None):
     """Create a ROC curve and compute the bootstrap AUC for the given variable and outcome
 


### PR DESCRIPTION
Used this to look at `spearmanr`.

Separately, passed some `kwargs` through in `cohort_bootstrap_auc` so things like `filter_fn` could be passed through.

@arahuja 
