### PR TITLE
Support joining on DataFrameLoaders with shared columns

### DIFF
--- a/cohorts/load.py
+++ b/cohorts/load.py
@@ -365,18 +365,16 @@ class Cohort(Collection):
         df_loader_dfs = {}
         col_counts = defaultdict(int)
         for df_loader in df_loaders:
-            loaded_df = df_loader.load_dataframe()
-            df_loader_dfs[df_loader] = loaded_df
-            for col in loaded_df.columns:
+            df_loader_dfs[df_loader] = df_loader.load_dataframe()
+            for col in df_loader_dfs[df_loader].columns:
                 col_counts[col] += 1
         for col, count in col_counts.items():
             # Don't rename columns that are not duplicated.
             if count > 1:
-                for df_loader in df_loader_dfs.keys():
-                    loaded_df = df_loader_dfs[df_loader]
+                for df_loader, loaded_df in df_loader_dfs.items():
                     # Don't rename a column that will be joined on.
                     if col != "patient_id" and col != df_loader.join_on:
-                        df_loader_dfs[df_loader] = loaded_df.rename(columns={col: "%s_%s" % (df_loader.name, col)})
+                        loaded_df.rename(columns={col: "%s_%s" % (df_loader.name, col)}, inplace=True)
 
         for df_loader, loaded_df in df_loader_dfs.items():
             old_len_df = len(df)

--- a/cohorts/load.py
+++ b/cohorts/load.py
@@ -374,7 +374,7 @@ class Cohort(Collection):
                 for df_loader, loaded_df in df_loader_dfs.items():
                     # Don't rename a column that will be joined on.
                     if col != "patient_id" and col != df_loader.join_on:
-                        loaded_df.rename(columns={col: "%s_%s" % (df_loader.name, col)}, inplace=True)
+                        loaded_df.rename(columns={col: "%s_%s" % (col, df_loader.name)}, inplace=True)
 
         for df_loader, loaded_df in df_loader_dfs.items():
             old_len_df = len(df)

--- a/cohorts/load.py
+++ b/cohorts/load.py
@@ -360,7 +360,7 @@ class Cohort(Collection):
         df = pd.DataFrame.from_records(patient_rows)
 
         # Are any columns duplicated in the DataFrame(s) to be joined?
-        # If so, rename those columns to be prefixed by the DataFrameLoader
+        # If so, rename those columns to be suffixed by the DataFrameLoader
         # name.
         df_loader_dfs = {}
         col_counts = defaultdict(int)


### PR DESCRIPTION
For example:

`join_with=["loader_a", "loader_b"]`

Where `loader_a` has columns `patient_id` `A` `B` `C` and `loader_b` has columns `patient_id` `C` `D`...

...will result in columns like:

```
`patient_id`
`A`
`B`
`loader_a_C`
`loader_b_C`
`D`
```

@arahuja 
