### PR TITLE
Fix versioneer settings

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,15 @@
+# Releasing Cohorts
+
+This document explains what do once your [Pull Request](https://www.atlassian.com/git/tutorials/making-a-pull-request/) has been reviewed and all final changes applied. Now you're ready merge your branch into master and release it to the world:
+
+1. Assign a version to the release you are preparing. Varcode uses [versioneer](https://github.com/warner/python-versioneer), so rather
+than explicitly editing `__version__` variable in the code you must instead tag the branch with your new version number (e.g. `git tag 1.2.3`).
+
+Warning: whether you should do `git tag v1.2.3` vs. `git tag 1.2.3` depends on versioneer settings, which can be found in `setup.cfg` and `_version.py` (because `_version.py` was generated via `setup.cfg` configuration, the two should match.) In `cohorts`, `git tag 1.2.3` (without the `v`) is what's expected.
+
+2. Once your candidate release branch is tagged you must then run `git push --tags` and merge the branch.
+
+3. After the `cohorts` unit tests complete successfully on Travis then the latest version
+of the code (with the version specified above) will be pushed to [PyPI](https://pypi.python.org/pypi) automatically. If you're curious about how automatic deployment is achieved, see our [Travis configuration](https://github.com/hammerlab/cohorts/blob/master/.travis.yml#L51).
+
+4. Finally, run [github-changelog-generator](https://github.com/skywinder/github-changelog-generator) from the `cohorts` directory (first, install it if needed).

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -5,11 +5,13 @@ This document explains what do once your [Pull Request](https://www.atlassian.co
 1. Assign a version to the release you are preparing. `cohorts` uses [versioneer](https://github.com/warner/python-versioneer), so rather
 than explicitly editing a `__version__` variable in the code you must instead tag the branch with your new version number (e.g. `git tag 1.2.3`).
 
-Warning: whether you should do `git tag v1.2.3` vs. `git tag 1.2.3` depends on versioneer settings, which can be found in `setup.cfg` and `_version.py` (because `_version.py` was generated from `setup.cfg` configuration, the two should match.) In `cohorts`, `git tag 1.2.3` (without the `v`) is what's expected.
-
 2. Once your candidate release branch is tagged you must then run `git push --tags` and merge the branch.
 
 3. After the `cohorts` unit tests complete successfully on Travis then the latest version
 of the code (with the version specified above) will be pushed to [PyPI](https://pypi.python.org/pypi) automatically. If you're curious about how automatic deployment is achieved, see our [Travis configuration](https://github.com/hammerlab/cohorts/blob/master/.travis.yml#L51).
 
-4. Finally, run [github-changelog-generator](https://github.com/skywinder/github-changelog-generator) from the `cohorts` directory (first, install it if needed).
+4. Finally, from a clean copy of the `master` branch, run [github-changelog-generator](https://github.com/skywinder/github-changelog-generator) from the `cohorts` directory (first, install it if needed). Then commit/push `master` to GitHub.
+
+You're done!
+
+General note about versioneer: whether you should do `git tag v1.2.3` vs. `git tag 1.2.3` depends on versioneer settings, which can be found in `setup.cfg` and `_version.py` (because `_version.py` was generated from `setup.cfg` configuration, the two should match.) In `cohorts`, `git tag 1.2.3` (without the `v`) is what's expected.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,10 +2,10 @@
 
 This document explains what do once your [Pull Request](https://www.atlassian.com/git/tutorials/making-a-pull-request/) has been reviewed and all final changes applied. Now you're ready merge your branch into master and release it to the world:
 
-1. Assign a version to the release you are preparing. Varcode uses [versioneer](https://github.com/warner/python-versioneer), so rather
-than explicitly editing `__version__` variable in the code you must instead tag the branch with your new version number (e.g. `git tag 1.2.3`).
+1. Assign a version to the release you are preparing. `cohorts` uses [versioneer](https://github.com/warner/python-versioneer), so rather
+than explicitly editing a `__version__` variable in the code you must instead tag the branch with your new version number (e.g. `git tag 1.2.3`).
 
-Warning: whether you should do `git tag v1.2.3` vs. `git tag 1.2.3` depends on versioneer settings, which can be found in `setup.cfg` and `_version.py` (because `_version.py` was generated via `setup.cfg` configuration, the two should match.) In `cohorts`, `git tag 1.2.3` (without the `v`) is what's expected.
+Warning: whether you should do `git tag v1.2.3` vs. `git tag 1.2.3` depends on versioneer settings, which can be found in `setup.cfg` and `_version.py` (because `_version.py` was generated from `setup.cfg` configuration, the two should match.) In `cohorts`, `git tag 1.2.3` (without the `v`) is what's expected.
 
 2. Once your candidate release branch is tagged you must then run `git push --tags` and merge the branch.
 

--- a/cohorts/_version.py
+++ b/cohorts/_version.py
@@ -40,7 +40,7 @@ def get_config():
     cfg = VersioneerConfig()
     cfg.VCS = "git"
     cfg.style = "pep440"
-    cfg.tag_prefix = "v"
+    cfg.tag_prefix = ""
     cfg.parentdir_prefix = "None"
     cfg.versionfile_source = "cohorts/_version.py"
     cfg.verbose = False


### PR DESCRIPTION
Update `_version.py` to be in sync with `setup.cfg` so that `cohorts.__version__` will show tagged releases.

Thanks to @arahuja for help debugging this.

Also adding a `RELEASING.md`.
