### PR TITLE
upgrade to varcode 0.5.1 and necessary deps

### DIFF
--- a/cohorts/varcode_utils.py
+++ b/cohorts/varcode_utils.py
@@ -1,4 +1,4 @@
-from varcode import EffectCollection, VariantCollection, Variant
+from varcode import EffectCollection, Variant
 
 def genome(variant_collection):
     return variant_collection[0].ensembl
@@ -11,7 +11,12 @@ class FilterableVariant(object):
 
     @property
     def variant_metadata(self):
-        return self.variant_collection.metadata[self.variant]
+        source_to_metadata = self.variant_collection.source_to_metadata_dict
+        return dict([
+                (source, source_to_metadata[source][self.variant])
+                for source in self.variant_collection.sources
+                if self.variant in source_to_metadata[source]
+            ])
 
     @property
     def genome(self):

--- a/cohorts/variant_filters.py
+++ b/cohorts/variant_filters.py
@@ -14,10 +14,8 @@
 
 from .variant_stats import variant_stats_from_variant
 
-import numpy as np
-from varcode import Substitution, Variant
+from varcode import Variant
 from varcode.common import memoize
-import re
 import pandas as pd
 from os import path
 

--- a/cohorts/variant_stats.py
+++ b/cohorts/variant_stats.py
@@ -68,7 +68,7 @@ def mutect_somatic_variant_stats(variant, variant_metadata):
     -------
     SomaticVariantStats
     """
-
+  
     sample_info = variant_metadata["sample_info"]
     # Ensure there are exactly two samples in the VCF, a tumor and normal
     assert len(sample_info) == 2, "More than two samples found in the somatic VCF"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
 pandas>=0.15
 seaborn>=0.7.0
 scipy>=0.17.0
-topiary==0.1.0
-mhctools>=0.3.0
-varcode==0.5.1
-pyensembl>=1.0.1
+topiary>=0.1.0, <0.2.0
+mhctools>=0.3.0, <0.4.0
+varcode>=0.5.1, <0.6.0
+pyensembl>=1.0.1, <1.1.0
 six>=1.10.0
 lifelines>=0.9.1.0
 scikit-learn>=0.17.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
 pandas>=0.15
 seaborn>=0.7.0
 scipy>=0.17.0
-topiary>=0.0.20, <0.1.0
-mhctools>=0.2.3, <0.3.0
-varcode==0.4.15
-pyensembl>=0.8.12, <1.0.0
+topiary==0.1.0
+mhctools>=0.3.0
+varcode==0.5.1
+pyensembl>=1.0.1
 six>=1.10.0
 lifelines>=0.9.1.0
 scikit-learn>=0.17.1
@@ -15,3 +15,4 @@ scikit-bio==0.4.2
 isovar==0.0.6
 patsy>=0.4.1
 mock>=2.0.0
+serializable>=0.0.8

--- a/test/test_count.py
+++ b/test/test_count.py
@@ -14,13 +14,13 @@
 
 from __future__ import print_function
 
-from varcode import ExonicSpliceSite, Substitution
+from varcode.effects.effect_classes import ExonicSpliceSite, Substitution
 from cohorts.variant_filters import no_filter
 
 from .data_generate import generate_vcfs
 from .functions import *
 
-from nose.tools import raises, eq_, ok_
+from nose.tools import eq_, ok_
 from mock import MagicMock
 from os import path
 from shutil import rmtree
@@ -129,8 +129,8 @@ def test_merge_two():
         cohort_variants = cohort.load_variants(filter_fn=None)
         for (sample, variants) in cohort_variants.items():
             for variant in variants:
-                metadata = variants.metadata[variant]
-                eq_(len(metadata), 2) # Each variant has two metadata entries
+                sources = variants.sources
+                eq_(len(sources), 2) # Each variant has two sources entries
 
     finally:
         if vcf_dir is not None and path.exists(vcf_dir):


### PR DESCRIPTION
Upgrading `varcode` and using `varcode`'s `union` and `intersection` functions. This should pass on Travis once `serializable==0.0.8` is released.
