### PR TITLE
Make API more consistent

### DIFF
--- a/cohorts/cohort.py
+++ b/cohorts/cohort.py
@@ -1126,6 +1126,8 @@ class Cohort(Collection):
         if plot_type not in ["boxplot", "barplot", "jointplot"]:
             raise ValueError("Invalid plot_type %s" % plot_type)
         plot_cols, df = self.as_dataframe(on, return_cols=True, **kwargs)
+        if len(plot_cols) != 2:
+            raise ValueError("Must be comparing two columns, but there are %d columns" % len(plot_cols))
         for plot_col in plot_cols:
             df = filter_not_null(df, plot_col)
         if x_col is None:

--- a/cohorts/cohort.py
+++ b/cohorts/cohort.py
@@ -930,7 +930,7 @@ class Cohort(Collection):
     def plot_col_from_cols(self, cols, only_allow_one=True, plot_col=None):
         if type(cols) == str:
             if plot_col is not None:
-                raise ValueError("plot_col is specified when it isn't ndeeded because there is only one col.")
+                raise ValueError("plot_col is specified when it isn't needed because there is only one col.")
             plot_col = cols
         elif type(cols) == list:
             # If e.g. an `on` dictionary is provided, that'll result in a list of cols.
@@ -1016,6 +1016,8 @@ class Cohort(Collection):
         plot_col : str, optional
             If on has many columns, this is the one whose values we are plotting.
             If on has a single column, this is unnecessary.
+            We might want many columns if, e.g. we're generating boolean_col from a
+            function as well.
         boolean_col : str
             Column name of boolean column to plot or compare against.
         boolean_label : None, optional

--- a/cohorts/utils.py
+++ b/cohorts/utils.py
@@ -16,6 +16,22 @@ from __future__ import print_function
 
 import re
 import warnings
+from collections import namedtuple
+
+class DataFrameHolder(namedtuple("DataFrameHolder", ["cols", "df"])):
+    """Holds a DataFrame along with associated columns of interest."""
+    def return_self(self, return_cols):
+        """Either return the DataFrame or the DataFrameHolder."""
+        if return_cols:
+            return self
+        else:
+            return self.df
+
+    @staticmethod
+    def return_obj(cols, df, return_cols=False):
+        """Construct a DataFrameHolder and then return either that or the DataFrame."""
+        df_holder = DataFrameHolder(cols=cols, df=df)
+        return df_holder.return_self(return_cols=return_cols)
 
 class InvalidDataError(ValueError):
     pass

--- a/pylintrc
+++ b/pylintrc
@@ -2,3 +2,4 @@
 # Without ignoring this, we get errors like:
 # E:249,20: Module 'numpy' has no 'nan' member (no-member)
 ignored-modules = numpy
+ignored-classes = DataFrameHolder

--- a/test/test_missing.py
+++ b/test/test_missing.py
@@ -58,13 +58,13 @@ def test_broken_vcf_path():
             patient_ids_with_missing_paths=["1"],
             missing_paths=["nonexistant_path"])
 
-        count_col, df = cohort.as_dataframe(snv_count)
+        df = cohort.as_dataframe(snv_count)
         eq_(len(df), 3)
-        ok_(np.isnan(list(df[count_col])[0]))
+        ok_(np.isnan(list(df["snv_count"])[0]))
 
-        count_col, df = cohort.as_dataframe(missense_snv_count)
+        df = cohort.as_dataframe(missense_snv_count)
         eq_(len(df), 3)
-        ok_(np.isnan(list(df[count_col])[0]))
+        ok_(np.isnan(list(df["missense_snv_count"])[0]))
     finally:
         if vcf_dir is not None and path.exists(vcf_dir):
             rmtree(vcf_dir)
@@ -82,13 +82,13 @@ def test_missing_vcf_path():
             patient_ids_with_missing_paths=["1"],
             missing_paths=[])
 
-        count_col, df = cohort.as_dataframe(snv_count)
+        df = cohort.as_dataframe(snv_count)
         eq_(len(df), 3)
-        ok_(np.isnan(list(df[count_col])[0]))
+        ok_(np.isnan(list(df["snv_count"])[0]))
 
-        count_col, df = cohort.as_dataframe(missense_snv_count)
+        df = cohort.as_dataframe(missense_snv_count)
         eq_(len(df), 3)
-        ok_(np.isnan(list(df[count_col])[0]))
+        ok_(np.isnan(list(df["missense_snv_count"])[0]))
     finally:
         if vcf_dir is not None and path.exists(vcf_dir):
             rmtree(vcf_dir)
@@ -110,12 +110,12 @@ def test_no_neoantigens():
                                    patient_ids_with_zero_neoantigens=["4", "5"],
                                    patient_ids_with_empty_neoantigens=["1"])
 
-        count_col, df = cohort.as_dataframe(neoantigen_count)
+        df = cohort.as_dataframe(neoantigen_count)
         eq_(len(df), 3)
 
         # This is used internally by plotting functions.
         # Ensure it filters NaN but not 0.
-        eq_(len(filter_not_null(df, count_col)), 2)
+        eq_(len(filter_not_null(df, "neoantigen_count")), 2)
     finally:
         if vcf_dir is not None and path.exists(vcf_dir):
             rmtree(vcf_dir)


### PR DESCRIPTION
In this PR:
- The default for `as_dataframe` is to always return just the `DataFrame`, unless `return_cols` is `True`. I use a `DataFrameHolder` `namedtuple` that's generally invisible to the user, in order to pass `return_cols` around and return the right thing.
- `col` is removed from `plot_benefit`, `plot_survival`, etc.
- The `on` API is standardized as `str`/function/list of `str`s or functions/dict of `str`s to `str`s or functions; `plot_benefit`, `plot_survival`, `plot_correlation`, etc. obey this.
- `plot_joint` is now removed in favor of `plot_correlation`. `plot_correlation` uses the `on` API to specify two variables rather than `on_two`.
- Added `coxph`, `bootstrap_auc` and `mean_bootstrap` AUC to the `cohorts` object, and they use the same `on` API.

Examples of the new API in action:

```
df = cohort.as_dataframe(on=missense_snv_count)
cols, df = cohort.as_dataframe(on={"aa": "2-factor score", "bb": missense_snv_count}, return_cols=True)
df = cohort.as_dataframe({"hello": "2-factor score", "goodbye": missense_snv_count})
cohort.plot_correlation(on={"aa": "2-factor score", "bb": missense_snv_count})
cohort.plot_correlation(on=["2-factor score", missense_snv_count])
cohort.mean_bootstrap_auc(on="Age")
cohort.mean_bootstrap_auc(on=missense_snv_count)
`cohort.coxph(on=[missense_snv_count, "Age"])`
```

Hopefully we can get this in before we acquire any new users. I figure this'll be `0.4.0`.

@arahuja cc @jburos 
