### PR TITLE
Fix variant stats

### DIFF
--- a/cohorts/cohort.py
+++ b/cohorts/cohort.py
@@ -484,7 +484,7 @@ class Cohort(Collection):
             merged_variants = self.load_from_cache(self.cache_names["variant"], patient.id, variant_cache_file_name)
             variant_collections = list()
             if merged_variants is None:
-                vcf_paths = patient.vcf_paths
+                vcf_paths = patient.snv_vcf_paths
                 variant_collections = [
                     varcode.load_vcf_fast(vcf_path)
                     for vcf_path in vcf_paths

--- a/cohorts/functions.py
+++ b/cohorts/functions.py
@@ -67,12 +67,37 @@ def get_patient_to_mb(cohort):
     patient_to_mb = dict(cohort.as_dataframe(join_with="ensembl_coverage")[["patient_id", "MB"]].to_dict("split")["data"])
     return patient_to_mb
 
+
 @count_function
-def snv_count(row, cohort, filter_fn, normalized_per_mb, **kwargs):
+def variant_count(row, cohort, filter_fn, normalized_per_mb, **kwargs):
     patient_id = row["patient_id"]
     return cohort.load_variants(
         patients=[cohort.patient_from_id(patient_id)],
         filter_fn=filter_fn,
+        **kwargs)
+
+@count_function
+def snv_count(row, cohort, filter_fn, normalized_per_mb, **kwargs):
+    patient_id = row["patient_id"]
+    def snv_filter_fn(filterable_variant, **kwargs):
+        assert filter_fn is not None, "filter_fn should never be None, but it is."
+        return (filterable_variant.variant.is_snv and
+                filter_fn(filterable_variant=filterable_variant, **kwargs))
+    return cohort.load_variants(
+        patients=[cohort.patient_from_id(patient_id)],
+        filter_fn=snv_filter_fn,
+        **kwargs)
+
+@count_function
+def indel_count(row, cohort, filter_fn, normalized_per_mb, **kwargs):
+    patient_id = row["patient_id"]
+    def indel_filter_fn(filterable_variant, **kwargs):
+        assert filter_fn is not None, "filter_fn should never be None, but it is."
+        return (filterable_variant.variant.is_indel and
+                filter_fn(filterable_variant=filterable_variant, **kwargs))
+    return cohort.load_variants(
+        patients=[cohort.patient_from_id(patient_id)],
+        filter_fn=indel_filter_fn,
         **kwargs)
 
 @count_function

--- a/cohorts/varcode_utils.py
+++ b/cohorts/varcode_utils.py
@@ -62,7 +62,7 @@ class FilterablePolyphen(FilterableVariant):
                                    variant_collection=variant_collection,
                                    patient=patient)
 
-def filter_variants(variant_collection, patient, filter_fn):
+def filter_variants(variant_collection, patient, filter_fn, **kwargs):
     """Filter variants from the Variant Collection
 
     Parameters
@@ -82,9 +82,10 @@ def filter_variants(variant_collection, patient, filter_fn):
             variant
             for variant in variant_collection
             if filter_fn(FilterableVariant(
-                    variant=variant,
-                    variant_collection=variant_collection,
-                    patient=patient))
+                        variant=variant,
+                        variant_collection=variant_collection,
+                        patient=patient,
+                        ), **kwargs)
         ])
     else:
         return variant_collection


### PR DESCRIPTION

Few changes:

1. Addresses issues #166 - variant stats lead to divide by zero error when total read count is 0 for a variant
2. Also addresses #167 - filtering variant stats by type, irrespective of merged file type
3. caches filtered variants as well as unfiltered variant collections
4. pass **kwargs to filter_fn, if provided. This enables more flexible filtering 
