### PR TITLE
Fix variant stats; cached filtered variants; add exonic counts; add progress bar

### DIFF
--- a/cohorts/cohort.py
+++ b/cohorts/cohort.py
@@ -506,6 +506,7 @@ class Cohort(Collection):
     def _hash_filter_fn(self, filter_fn, **kwargs):
         if filter_fn is None:
             return 'filter-none'
+        filter_fn_name = filter_fn.__name__
         logger.debug('Computing hash for filter_fn: {} with kwargs {}'.format(filter_fn_name, str(dict(**kwargs))))
         # function source code
         fn_source = str(dill.source.getsource(filter_fn))

--- a/cohorts/cohort.py
+++ b/cohorts/cohort.py
@@ -556,7 +556,7 @@ class Cohort(Collection):
             logger.info("... disabling filtered cache due to python version")
             use_filtered_cache = False
             
-        ## get cache name, if possible
+        ## confirm that we can get cache-name (else don't use filtered cache)
         if use_filtered_cache:
             logger.debug("... identifying filtered-cache file name")
             try:
@@ -564,18 +564,18 @@ class Cohort(Collection):
                 filtered_cache_file_name = "%s-variants.%s.pkl" % (self.merge_type,
                                                                    self._hash_filter_fn(filter_fn, **kwargs))
             except:
+                logger.warning("... error identifying filtered-cache file name for patient {}: {}".format(
+                        patient.id, filter_fn_name))
                 use_filtered_cache = False
-        
-        ## read from cache, if possible
-        if use_filtered_cache:
-            logger.debug("... trying to load filtered variants from cache: {}".format(filtered_cache_file_name))
-            try:
-                cached = self.load_from_cache(self.cache_names["variant"], patient.id, filtered_cache_file_name)
-                if cached is not None:
-                    return cached
-            except:
-                logger.warn("Error loading variants from cache for patient: {}".format(patient.id))
-                pass
+            finally:
+                logger.debug("... trying to load filtered variants from cache: {}".format(filtered_cache_file_name))
+                try:
+                    cached = self.load_from_cache(self.cache_names["variant"], patient.id, filtered_cache_file_name)
+                    if cached is not None:
+                        return cached
+                except:
+                    logger.warning("Error loading variants from cache for patient: {}".format(patient.id))
+                    pass
         
         ## get merged variants
         logger.debug("... getting merged variants for: {}".format(patient.id))

--- a/cohorts/cohort.py
+++ b/cohorts/cohort.py
@@ -567,7 +567,7 @@ class Cohort(Collection):
                 logger.warning("... error identifying filtered-cache file name for patient {}: {}".format(
                         patient.id, filter_fn_name))
                 use_filtered_cache = False
-            finally:
+            else:
                 logger.debug("... trying to load filtered variants from cache: {}".format(filtered_cache_file_name))
                 try:
                     cached = self.load_from_cache(self.cache_names["variant"], patient.id, filtered_cache_file_name)

--- a/cohorts/cohort.py
+++ b/cohorts/cohort.py
@@ -328,7 +328,7 @@ class Cohort(Collection):
             else:
                 func = lambda row: on(row=row, cohort=self, **kwargs)
             tqdm.pandas(desc=col)
-            df[col] = df.progress_apply(func, axis=1)
+            df[col] = df.progress_apply(func, axis=1) ## depends on tqdm on prev line
             return DataFrameHolder(col, df)
 
         def func_name(func, num=0):
@@ -377,7 +377,7 @@ class Cohort(Collection):
         Instead of joining a DataFrameJoiner with the Cohort in `as_dataframe`, sometimes
         we may want to just directly load a particular DataFrame.
         """
-        logger.debug('loading dataframe: {}'.format(df_loader_name))
+        logger.debug("loading dataframe: {}".format(df_loader_name))
         # Get the DataFrameLoader object corresponding to this name.
         df_loaders = [df_loader for df_loader in self.df_loaders if df_loader.name == df_loader_name]
 
@@ -405,14 +405,14 @@ class Cohort(Collection):
         if not self.cache_results:
             return None
         
-        logger.debug('loading patient {} data from {} cache: {}'.format(patient_id, cache_name, file_name))
+        logger.debug("loading patient {} data from {} cache: {}".format(patient_id, cache_name, file_name))
 
         cache_dir = path.join(self.cache_dir, cache_name)
         patient_cache_dir = path.join(cache_dir, str(patient_id))
         cache_file = path.join(patient_cache_dir, file_name)
 
         if not path.exists(cache_file):
-            logger.debug('... file does not exist. Checking for older format.')
+            logger.debug("... cache file does not exist. Checking for older format.")
             # We removed variant_type from the cache name. Eventually remove this notification.
             if (path.exists(path.join(patient_cache_dir, "snv-" + file_name)) or
                 path.exists(path.join(patient_cache_dir, "indel-" + file_name))):
@@ -420,7 +420,7 @@ class Cohort(Collection):
             return None
 
         if self.check_provenance:
-            logger.debug('... Checking cache provenance')
+            logger.debug("... Checking cache provenance")
             num_discrepant = compare_provenance(
                 this_provenance = self.generate_provenance(),
                 other_provenance = self.load_provenance(patient_cache_dir),
@@ -429,20 +429,20 @@ class Cohort(Collection):
                 )
         try:
             if path.splitext(cache_file)[1] == ".csv":
-                logger.debug('... Loading cache as csv file')
+                logger.debug("... Loading cache as csv file")
                 return pd.read_csv(cache_file, dtype={"patient_id": object})
             else:
-                logger.debug('... Loading cache as pickled file')
+                logger.debug("... Loading cache as pickled file")
                 with open(cache_file, "rb") as f:
                     return pickle.load(f)
-        except:
+        except IOError:
             return None
 
     def save_to_cache(self, obj, cache_name, patient_id, file_name):
         if not self.cache_results:
             return
         
-        logger.debug('saving patient {} data to {} cache: {}'.format(patient_id, cache_name, file_name))
+        logger.debug("saving patient {} data to {} cache: {}".format(patient_id, cache_name, file_name))
 
         cache_dir = path.join(self.cache_dir, cache_name)
         patient_cache_dir = path.join(cache_dir, str(patient_id))
@@ -472,6 +472,15 @@ class Cohort(Collection):
                 return patient
         raise ValueError("No patient with ID %s found" % id)
 
+    def _get_function_name(self, fn, default="None"):
+        """ Return name of function, using default value if function not defined
+        """
+        if fn is None:
+            fn_name = default
+        else:
+            fn_name = fn.__name__
+        return fn_name
+    
     def load_variants(self, patients=None, filter_fn=None, **kwargs):
         """Load a dictionary of patient_id to varcode.VariantCollection
 
@@ -489,11 +498,8 @@ class Cohort(Collection):
             Dictionary of patient_id to VariantCollection
         """
         filter_fn = first_not_none_param([filter_fn, self.filter_fn], no_filter)
-        if filter_fn is None:
-            filter_fn_name = 'None'
-        else:
-            filter_fn_name = filter_fn.__name__
-        logger.debug('loading variants with filter_fn: {}'.format(filter_fn_name))
+        filter_fn_name = self._get_function_name(filter_fn)
+        logger.debug("loading variants with filter_fn: {}".format(filter_fn_name))
         patient_variants = {}
 
         for patient in self.iter_patients(patients):
@@ -502,95 +508,102 @@ class Cohort(Collection):
                 patient_variants[patient.id] = variants
         return patient_variants
     
-    
     def _hash_filter_fn(self, filter_fn, **kwargs):
-        if filter_fn is None:
-            return 'filter-none'
-        filter_fn_name = filter_fn.__name__
-        logger.debug('Computing hash for filter_fn: {} with kwargs {}'.format(filter_fn_name, str(dict(**kwargs))))
-        # function source code
+        """ Construct string representing state of filter_fn
+            Used to cache filtered variants or effects uniquely depending on filter fn values
+        """
+        filter_fn_name = self._get_function_name(filter_fn, default="filter-none")
+        logger.debug("Computing hash for filter_fn: {} with kwargs {}".format(filter_fn_name, str(dict(**kwargs))))
+        # hash function source code
         fn_source = str(dill.source.getsource(filter_fn))
-        pickled_fn_source = pickle.dumps(fn_source)
-        # kwarg values
+        pickled_fn_source = pickle.dumps(fn_source) ## encode as byte string
+        hashed_fn_source = int(hashlib.sha1(pickled_fn_source).hexdigest(), 16) % (10 ** 11)
+        # hash kwarg values
         kw_dict = dict(**kwargs)
         kw_hash = list()
         if not kw_dict:
-            kw_hash = ['default']
+            kw_hash = ["default"]
         else:
-            [kw_hash.append('{}-{}'.format(key, h)) for (key, h) in sorted(kw_dict.items())]
-        # closure vars
-        closure = 'null'
+            [kw_hash.append("{}-{}".format(key, h)) for (key, h) in sorted(kw_dict.items())]
+        # hash closure vars - for case where filter_fn is defined within closure of filter_fn
+        closure = "null"
         nonlocals = inspect.getclosurevars(filter_fn).nonlocals
         for (key, val) in nonlocals.items():
+            ## capture hash for any function within closure
             if inspect.isfunction(val):
-                closure = '{}-{}'.format(self._hash_filter_fn(val).__name__, self._hash_filter_fn(val))
-        # construct final hashed_fn
-        hashed_fn = '.'.join(['-'.join([filter_fn.__name__,
-                                        int(hashlib.sha1(pickled_fn_source).hexdigest(), 16) % (10 ** 11)]),
-                              '.'.join(kw_hash),
+                closure = "{}-{}".format(self._hash_filter_fn(val).__name__, self._hash_filter_fn(val))
+        # construct final string comprising hashed components
+        hashed_fn = ".".join(["-".join([filter_fn_name,
+                                        hashed_fn_source]),
+                              ".".join(kw_hash),
                               closure]
                             )
         return hashed_fn
-            
-        
     
     def _load_single_patient_variants(self, patient, filter_fn, use_cache=True, **kwargs):
-        if filter_fn is None:
-            filter_fn_name = 'None'
-        else:
-            filter_fn_name = filter_fn.__name__
-        logger.debug('loading variants for patient {} with filter_fn {}'.format(patient.id, filter_fn_name))
+        """ Load filtered, merged variants for a single patient, optionally using cache
+        
+            Note that filtered variants are first merged before filtering, and 
+                each step is cached independently. Turn on debug statements for more
+                details about cached files.
+                
+            Use `_load_single_patient_merged_variants` to see merged variants without filtering.
+        """
+        filter_fn_name = self._get_function_name(filter_fn)
+        logger.debug("loading variants for patient {} with filter_fn {}".format(patient.id, filter_fn_name))
         use_filtered_cache = use_cache
         if sys.version_info < (3, 3):
-            logger.debug('... disabling filtered cache due to python version')
+            logger.info("... disabling filtered cache due to python version")
             use_filtered_cache = False
             
         ## get cache name, if possible
         if use_filtered_cache:
-            logger.debug('... identifying filtered-cache file name')
+            logger.debug("... identifying filtered-cache file name")
             try:
                 ## try to load filtered variants from cache
                 filtered_cache_file_name = "%s-variants.%s.pkl" % (self.merge_type,
-                                                                          self._hash_filter_fn(filter_fn, **kwargs))
+                                                                   self._hash_filter_fn(filter_fn, **kwargs))
             except:
                 use_filtered_cache = False
         
         ## read from cache, if possible
         if use_filtered_cache:
-            logger.debug('... trying to load filtered variants from cache: {}'.format(filtered_cache_file_name))
+            logger.debug("... trying to load filtered variants from cache: {}".format(filtered_cache_file_name))
             try:
                 cached = self.load_from_cache(self.cache_names["variant"], patient.id, filtered_cache_file_name)
                 if cached is not None:
                     return cached
             except:
-                logger.warn('Error loading variants from cache for patient: {}'.format(patient.id))
+                logger.warn("Error loading variants from cache for patient: {}".format(patient.id))
                 pass
         
         ## get merged variants
-        logger.debug('... getting merged variants for: {}'.format(patient.id))
+        logger.debug("... getting merged variants for: {}".format(patient.id))
         merged_variants = self._load_single_patient_merged_variants(patient, use_cache=use_cache)
 
-        # Note that this is the number of variant collections and not the number of
-        # variants. 0 variants will lead to 0 neoantigens, for example, but 0 variant
-        # collections will lead to NaN variants and neoantigens.
+        # Note None here is different from 0. We want to preserve None
         if merged_variants is None:
             logger.info("Variants did not exist for patient %s" % patient.id)
             return None
         
-        logger.debug('... applying filters to variants for: {}'.format(patient.id))
+        logger.debug("... applying filters to variants for: {}".format(patient.id))
         filtered_variants = filter_variants(variant_collection=merged_variants,
                                             patient=patient,
                                             filter_fn=filter_fn,
                                             **kwargs)
         if use_filtered_cache:
-            logger.debug('... saving filtered variants to cache: {}'.format(filtered_cache_file_name))
+            logger.debug("... saving filtered variants to cache: {}".format(filtered_cache_file_name))
             self.save_to_cache(filtered_variants, self.cache_names["variant"], patient.id, filtered_cache_file_name)
         return filtered_variants
-
     
     def _load_single_patient_merged_variants(self, patient, use_cache=True):
-        logger.debug('loading merged variants for patient {}'.format(patient.id))
-        failed_io = False
+        """ Load merged variants for a single patient, optionally using cache
+        
+            Note that merged variants are not filtered. 
+            Use `_load_single_patient_variants` to get filtered variants
+        """
+        logger.debug("loading merged variants for patient {}".format(patient.id))
+        no_variants = False
         try:
             # get merged-variants from cache
             if use_cache:
@@ -615,7 +628,7 @@ class Cohort(Collection):
                     raise ValueError("Don't know how to read %s" % patient_variants)
             # merge variant-collections
             if len(variant_collections) == 0:
-                failed_io = True
+                no_variants = True
             elif len(variant_collections) == 1:
                 # There is nothing to merge
                 variants = variant_collections[0]
@@ -623,23 +636,22 @@ class Cohort(Collection):
             else:
                 merged_variants = self._merge_variant_collections(variant_collections, self.merge_type)
         except IOError:
-            failed_io = True
+            no_variants = True
 
         # Note that this is the number of variant collections and not the number of
         # variants. 0 variants will lead to 0 neoantigens, for example, but 0 variant
         # collections will lead to NaN variants and neoantigens.
-        if failed_io:
+        if no_variants:
             print("Variants did not exist for patient %s" % patient.id)
-            return None
+            merged_variants = None
         
-        # save merged & filtered variants to file
+        # save merged variants to file
         if use_cache:
             self.save_to_cache(merged_variants, self.cache_names["variant"], patient.id, variant_cache_file_name)
         return merged_variants
     
-    
     def _merge_variant_collections(self, variant_collections, merge_type):
-        logger.debug('Merging variants using merge type: {}'.format(merge_type))
+        logger.debug("Merging variants using merge type: {}".format(merge_type))
         assert merge_type in ["union", "intersection"], "Unknown merge type: %s" % merge_type
         head = variant_collections[0]
         if merge_type == "union":
@@ -755,12 +767,8 @@ class Cohort(Collection):
              Dictionary of patient_id to varcode.EffectCollection
         """
         filter_fn = first_not_none_param([filter_fn, self.filter_fn], no_filter)
-        if filter_fn is None:
-            logger.warn('Loading patient effects with filter_fn: None')
-            filter_fn_name = 'None'
-        else:
-            filter_fn_name = filter_fn.__name__
-        logger.debug('loading effects with filter_fn {}'.format(filter_fn_name))
+        filter_fn_name = self._get_function_name(filter_fn)
+        logger.debug("loading effects with filter_fn {}".format(filter_fn_name))
         patient_effects = {}
         for patient in self.iter_patients(patients):
             effects = self._load_single_patient_effects(
@@ -771,11 +779,8 @@ class Cohort(Collection):
 
     def _load_single_patient_effects(self, patient, only_nonsynonymous, all_effects, filter_fn, **kwargs):
         cached_file_name = "%s-effects.pkl" % self.merge_type
-        if filter_fn is None:
-            filter_fn_name = 'None'
-        else:
-            filter_fn_name = filter_fn.__name__
-        logger.debug('loading effects for patient {} with filter_fn {}'.format(patient.id, filter_fn_name))
+        filter_fn_name = self._get_function_name(filter_fn)
+        logger.debug("loading effects for patient {} with filter_fn {}".format(patient.id, filter_fn_name))
 
         # Don't filter here, as these variants are used to generate the
         # effects cache; and cached items are never filtered.
@@ -843,12 +848,12 @@ class Cohort(Collection):
 
         ensembl_release = cached_release(self.kallisto_ensembl_version)
 
-        kallisto_data['gene_name'] = \
-            kallisto_data['target_id'].map(lambda t: ensembl_release.gene_name_of_transcript_id(t))
+        kallisto_data["gene_name"] = \
+            kallisto_data["target_id"].map(lambda t: ensembl_release.gene_name_of_transcript_id(t))
 
         # sum counts across genes
         kallisto_data = \
-            kallisto_data.groupby(['patient_id', 'gene_name'])[['est_counts']].sum().reset_index()
+            kallisto_data.groupby(["patient_id", "gene_name"])[["est_counts"]].sum().reset_index()
 
         return kallisto_data
 

--- a/cohorts/cohort.py
+++ b/cohorts/cohort.py
@@ -484,7 +484,7 @@ class Cohort(Collection):
             merged_variants = self.load_from_cache(self.cache_names["variant"], patient.id, variant_cache_file_name)
             variant_collections = list()
             if merged_variants is None:
-                vcf_paths = patient.vcf_paths
+                vcf_paths = patient.snv_vcf_paths
                 variant_collections = [
                     varcode.load_vcf_fast(vcf_path)
                     for vcf_path in vcf_paths

--- a/cohorts/cohort.py
+++ b/cohorts/cohort.py
@@ -499,14 +499,14 @@ class Cohort(Collection):
         failed_io = False
         try:
             ## try to load filtered variants from cache
-            filtered_cache_file_name = "%s-%s-variants.filter-%s.pkl" % (self.variant_type, self.merge_type,
+            filtered_cache_file_name = "%s-variants.filter-%s.pkl" % (self.merge_type,
                                                                  self._hash_filter_fn(filter_fn, **kwargs))
             cached = self.load_from_cache(self.cache_names["variant"], patient.id, filtered_cache_file_name)
             if cached is not None:
                 return cached
             
             ## load unfiltered variants into list of collections
-            variant_cache_file_name = "%s-%s-variants.pkl" % (self.variant_type, self.merge_type)
+            variant_cache_file_name = "%s-variants.pkl" % (self.merge_type)
             merged_variants = self.load_from_cache(self.cache_names["variant"], patient.id, variant_cache_file_name)
             variant_collections = []
             if merged_variants is None:

--- a/cohorts/cohort.py
+++ b/cohorts/cohort.py
@@ -26,6 +26,7 @@ import dill
 import hashlib
 import inspect
 import sys
+import logging
 
 # pylint doesn't like this line
 # pylint: disable=no-name-in-module
@@ -59,6 +60,8 @@ from .varcode_utils import (filter_variants, filter_effects,
 from .variant_filters import no_filter
 from .styling import set_styling
 from . import variant_filters
+
+logger = logging.getLogger(__name__)
 
 class Cohort(Collection):
     """

--- a/cohorts/cohort.py
+++ b/cohorts/cohort.py
@@ -47,6 +47,7 @@ from isovar.protein_sequence import variants_to_protein_sequences_dataframe
 from pysam import AlignmentFile
 from scipy.stats import pearsonr
 from collections import defaultdict
+from tqdm import tqdm
 
 from .dataframe_loader import DataFrameLoader
 from .utils import DataFrameHolder, first_not_none_param, filter_not_null, InvalidDataError, strip_column_names as _strip_column_names, get_logger
@@ -326,7 +327,8 @@ class Cohort(Collection):
                 func = lambda row: on(row=row, **kwargs)
             else:
                 func = lambda row: on(row=row, cohort=self, **kwargs)
-            df[col] = df.apply(func, axis=1)
+            tqdm.pandas(desc=col)
+            df[col] = df.progress_apply(func, axis=1)
             return DataFrameHolder(col, df)
 
         def func_name(func, num=0):

--- a/cohorts/cohort.py
+++ b/cohorts/cohort.py
@@ -510,7 +510,7 @@ class Cohort(Collection):
         logger.debug('Computing hash for filter_fn: {} with kwargs {}'.format(filter_fn_name, str(dict(**kwargs))))
         # function source code
         fn_source = str(dill.source.getsource(filter_fn))
-        hashed_fn_source = pickle.dumps(fn_source)
+        pickled_fn_source = pickle.dumps(fn_source)
         # kwarg values
         kw_dict = dict(**kwargs)
         kw_hash = list()
@@ -526,7 +526,7 @@ class Cohort(Collection):
                 closure = '{}-{}'.format(self._hash_filter_fn(val).__name__, self._hash_filter_fn(val))
         # construct final hashed_fn
         hashed_fn = '.'.join(['-'.join([filter_fn.__name__,
-                                        int(hashlib.sha1(hashed_fn_source).hexdigest(), 16) % (10 ** 11)]),
+                                        int(hashlib.sha1(pickled_fn_source).hexdigest(), 16) % (10 ** 11)]),
                               '.'.join(kw_hash),
                               closure]
                             )

--- a/cohorts/cohort.py
+++ b/cohorts/cohort.py
@@ -402,7 +402,7 @@ class Cohort(Collection):
     def load_from_cache(self, cache_name, patient_id, file_name):
         if not self.cache_results:
             return None
-
+        
         cache_dir = path.join(self.cache_dir, cache_name)
         patient_cache_dir = path.join(cache_dir, str(patient_id))
         cache_file = path.join(patient_cache_dir, file_name)
@@ -421,12 +421,14 @@ class Cohort(Collection):
                 left_outer_diff = "In current environment but not cached in %s for patient %s" % (cache_name, patient_id),
                 right_outer_diff = "In cached %s for patient %s but not current" % (cache_name, patient_id)
                 )
-
-        if path.splitext(cache_file)[1] == ".csv":
-            return pd.read_csv(cache_file, dtype={"patient_id": object})
-        else:
-            with open(cache_file, "rb") as f:
-                return pickle.load(f)
+        try:
+            if path.splitext(cache_file)[1] == ".csv":
+                return pd.read_csv(cache_file, dtype={"patient_id": object})
+            else:
+                with open(cache_file, "rb") as f:
+                    return pickle.load(f)
+        except:
+            return None
 
     def save_to_cache(self, obj, cache_name, patient_id, file_name):
         if not self.cache_results:

--- a/cohorts/cohort.py
+++ b/cohorts/cohort.py
@@ -729,7 +729,7 @@ class Cohort(Collection):
                                filter_fn=filter_fn)
 
     def load_effects(self, patients=None, only_nonsynonymous=False,
-                     all_effects=False, filter_fn=None):
+                     all_effects=False, filter_fn=None, **kwargs):
         """Load a dictionary of patient_id to varcode.EffectCollection
 
         Note that this only loads one effect per variant.
@@ -761,12 +761,12 @@ class Cohort(Collection):
         patient_effects = {}
         for patient in self.iter_patients(patients):
             effects = self._load_single_patient_effects(
-                patient, only_nonsynonymous, all_effects, filter_fn)
+                patient, only_nonsynonymous, all_effects, filter_fn, **kwargs)
             if effects is not None:
                 patient_effects[patient.id] = effects
         return patient_effects
 
-    def _load_single_patient_effects(self, patient, only_nonsynonymous, all_effects, filter_fn):
+    def _load_single_patient_effects(self, patient, only_nonsynonymous, all_effects, filter_fn, **kwargs):
         cached_file_name = "%s-effects.pkl" % self.merge_type
         if filter_fn is None:
             filter_fn_name = 'None'
@@ -793,7 +793,8 @@ class Cohort(Collection):
             return filter_effects(effect_collection=cached,
                                   variant_collection=variants,
                                   patient=patient,
-                                  filter_fn=filter_fn)
+                                  filter_fn=filter_fn,
+                                 **kwargs)
 
         effects = variants.effects()
 
@@ -813,7 +814,8 @@ class Cohort(Collection):
                 nonsynonymous_effects if only_nonsynonymous else effects),
             variant_collection=variants,
             patient=patient,
-            filter_fn=filter_fn)
+            filter_fn=filter_fn,
+            **kwargs)
 
     def load_kallisto(self):
         """

--- a/cohorts/functions.py
+++ b/cohorts/functions.py
@@ -79,10 +79,10 @@ def variant_count(row, cohort, filter_fn, normalized_per_mb, **kwargs):
 
 @count_function
 def exonic_variant_count(row, cohort, filter_fn, normalized_per_mb, **kwargs):
-    def exonic_filter_fn(filterable_effect):
+    def exonic_filter_fn(filterable_effect, **kwargs):
         assert filter_fn is not None, "filter_fn should never be None, but it is."
         return (isinstance(filterable_effect.effect, Exonic) and
-                filter_fn(filterable_effect))
+                filter_fn(filterable_effect, **kwargs))
     # This only loads one effect per variant.
     patient_id = row["patient_id"]
     return cohort.load_effects(
@@ -118,10 +118,10 @@ def indel_count(row, cohort, filter_fn, normalized_per_mb, **kwargs):
 
 @count_function
 def missense_snv_count(row, cohort, filter_fn, normalized_per_mb, **kwargs):
-    def missense_filter_fn(filterable_effect):
+    def missense_filter_fn(filterable_effect, **kwargs):
         assert filter_fn is not None, "filter_fn should never be None, but it is."
         return (type(filterable_effect.effect) == Substitution and
-                filter_fn(filterable_effect))
+                filter_fn(filterable_effect, **kwargs))
     # This only loads one effect per variant.
     patient_id = row["patient_id"]
     return cohort.load_effects(
@@ -153,11 +153,11 @@ def nonsynonymous_snv_count(row, cohort, filter_fn, normalized_per_mb, **kwargs)
 
 @count_function
 def missense_snv_count(row, cohort, filter_fn, normalized_per_mb, **kwargs):
-    def missense_filter_fn(filterable_effect):
+    def missense_filter_fn(filterable_effect, **kwargs):
         assert filter_fn is not None, "filter_fn should never be None, but it is."
         return (type(filterable_effect.effect) == Substitution and
                 filterable_effect.variant.is_snv and
-                filter_fn(filterable_effect))
+                filter_fn(filterable_effect, **kwargs))
     # This only loads one effect per variant.
     patient_id = row["patient_id"]
     return cohort.load_effects(
@@ -168,11 +168,11 @@ def missense_snv_count(row, cohort, filter_fn, normalized_per_mb, **kwargs):
 
 @count_function
 def exonic_snv_count(row, cohort, filter_fn, normalized_per_mb, **kwargs):
-    def exonic_filter_fn(filterable_effect):
+    def exonic_filter_fn(filterable_effect, **kwargs):
         assert filter_fn is not None, "filter_fn should never be None, but it is."
         return (isinstance(filterable_effect.effect, Exonic) and
                 filterable_effect.variant.is_snv and
-                filter_fn(filterable_effect))
+                filter_fn(filterable_effect, **kwargs))
     # This only loads one effect per variant.
     patient_id = row["patient_id"]
     return cohort.load_effects(
@@ -190,13 +190,13 @@ def neoantigen_count(row, cohort, filter_fn, normalized_per_mb, **kwargs):
 
 @use_defaults
 def expressed_missense_snv_count(row, cohort, filter_fn, normalized_per_mb, **kwargs):
-    def expressed_filter_fn(filterable_effect):
+    def expressed_filter_fn(filterable_effect, **kwargs):
         assert filter_fn is not None, "filter_fn should never be None, but it is."
         return filter_fn(filterable_effect) and effect_expressed_filter(filterable_effect)
     return missense_snv_count(row=row,
                               cohort=cohort,
                               filter_fn=expressed_filter_fn,
-                              normalized_per_mb=normalized_per_mb)
+                              normalized_per_mb=normalized_per_mb, **kwargs)
 
 @use_defaults
 def expressed_neoantigen_count(row, cohort, filter_fn, normalized_per_mb, **kwargs):

--- a/cohorts/functions.py
+++ b/cohorts/functions.py
@@ -78,6 +78,20 @@ def variant_count(row, cohort, filter_fn, normalized_per_mb, **kwargs):
         **kwargs)
 
 @count_function
+def exonic_variant_count(row, cohort, filter_fn, normalized_per_mb, **kwargs):
+    def exonic_filter_fn(filterable_effect):
+        assert filter_fn is not None, "filter_fn should never be None, but it is."
+        return (isinstance(filterable_effect.effect, Exonic) and
+                filter_fn(filterable_effect))
+    # This only loads one effect per variant.
+    patient_id = row["patient_id"]
+    return cohort.load_effects(
+        only_nonsynonymous=False,
+        patients=[cohort.patient_from_id(patient_id)],
+        filter_fn=exonic_filter_fn,
+        **kwargs)
+
+@count_function
 def snv_count(row, cohort, filter_fn, normalized_per_mb, **kwargs):
     patient_id = row["patient_id"]
     def snv_filter_fn(filterable_variant, **kwargs):
@@ -164,7 +178,7 @@ def exonic_snv_count(row, cohort, filter_fn, normalized_per_mb, **kwargs):
     return cohort.load_effects(
         only_nonsynonymous=True,
         patients=[cohort.patient_from_id(patient_id)],
-        filter_fn=missense_filter_fn,
+        filter_fn=exonic_filter_fn,
         **kwargs)
 
 @count_function

--- a/cohorts/functions.py
+++ b/cohorts/functions.py
@@ -68,7 +68,6 @@ def get_patient_to_mb(cohort):
     patient_to_mb = dict(cohort.as_dataframe(join_with="ensembl_coverage")[["patient_id", "MB"]].to_dict("split")["data"])
     return patient_to_mb
 
-
 @count_function
 def variant_count(row, cohort, filter_fn, normalized_per_mb, **kwargs):
     patient_id = row["patient_id"]
@@ -104,18 +103,16 @@ def snv_count(row, cohort, filter_fn, normalized_per_mb, **kwargs):
         **kwargs)
 
 @count_function
-def indel_count(row, cohort, filter_fn, normalized_per_mb, **kwargs):
+def deletion_count(row, cohort, filter_fn, normalized_per_mb, **kwargs):
     patient_id = row["patient_id"]
-    def indel_filter_fn(filterable_variant, **kwargs):
+    def deletion_filter_fn(filterable_variant, **kwargs):
         assert filter_fn is not None, "filter_fn should never be None, but it is."
         return (filterable_variant.variant.is_indel and
                 filter_fn(filterable_variant=filterable_variant, **kwargs))
     return cohort.load_variants(
         patients=[cohort.patient_from_id(patient_id)],
-        filter_fn=indel_filter_fn,
+        filter_fn=deletion_filter_fn,
         **kwargs)
-
-
 
 @count_function
 def effect_count(row, cohort, filter_fn, normalized_per_mb, **kwargs):
@@ -126,7 +123,6 @@ def effect_count(row, cohort, filter_fn, normalized_per_mb, **kwargs):
         patients=[cohort.patient_from_id(patient_id)],
         filter_fn=filter_fn,
         **kwargs)
-    
 
 @count_function
 def nonsynonymous_snv_count(row, cohort, filter_fn, normalized_per_mb, **kwargs):
@@ -155,7 +151,7 @@ def missense_snv_count(row, cohort, filter_fn, normalized_per_mb, **kwargs):
 
 @count_function
 def exonic_snv_count(row, cohort, filter_fn, normalized_per_mb, **kwargs):
-    def exonic_filter_fn(filterable_effect, **kwargs):
+    def exonic_snv_filter_fn(filterable_effect, **kwargs):
         assert filter_fn is not None, "filter_fn should never be None, but it is."
         return (isinstance(filterable_effect.effect, Exonic) and
                 filterable_effect.variant.is_snv and
@@ -165,7 +161,7 @@ def exonic_snv_count(row, cohort, filter_fn, normalized_per_mb, **kwargs):
     return cohort.load_effects(
         only_nonsynonymous=True,
         patients=[cohort.patient_from_id(patient_id)],
-        filter_fn=exonic_filter_fn,
+        filter_fn=exonic_snv_filter_fn,
         **kwargs)
 
 @count_function
@@ -184,8 +180,8 @@ def exonic_silent_snv_count(row, cohort, filter_fn, normalized_per_mb, **kwargs)
         **kwargs)
 
 @count_function
-def exonic_indel_count(row, cohort, filter_fn, normalized_per_mb, **kwargs):
-    def exonic_indel_filter_fn(filterable_effect, **kwargs):
+def exonic_deletion_count(row, cohort, filter_fn, normalized_per_mb, **kwargs):
+    def exonic_deletion_filter_fn(filterable_effect, **kwargs):
         assert filter_fn is not None, "filter_fn should never be None, but it is."
         return (isinstance(filterable_effect.effect, Exonic) and
                 filterable_effect.variant.is_deletion and
@@ -195,12 +191,12 @@ def exonic_indel_count(row, cohort, filter_fn, normalized_per_mb, **kwargs):
     return cohort.load_effects(
         only_nonsynonymous=True,
         patients=[cohort.patient_from_id(patient_id)],
-        filter_fn=exonic_indel_filter_fn,
+        filter_fn=exonic_deletion_filter_fn,
         **kwargs)
 
 @count_function
-def exonic_insert_count(row, cohort, filter_fn, normalized_per_mb, **kwargs):
-    def exonic_insert_filter_fn(filterable_effect, **kwargs):
+def exonic_insertion_count(row, cohort, filter_fn, normalized_per_mb, **kwargs):
+    def exonic_insertion_filter_fn(filterable_effect, **kwargs):
         assert filter_fn is not None, "filter_fn should never be None, but it is."
         return (isinstance(filterable_effect.effect, Exonic) and
                 filterable_effect.variant.is_insertion and
@@ -210,7 +206,7 @@ def exonic_insert_count(row, cohort, filter_fn, normalized_per_mb, **kwargs):
     return cohort.load_effects(
         only_nonsynonymous=True,
         patients=[cohort.patient_from_id(patient_id)],
-        filter_fn=exonic_insert_filter_fn,
+        filter_fn=exonic_insertion_filter_fn,
         **kwargs)
 
 @count_function

--- a/cohorts/functions.py
+++ b/cohorts/functions.py
@@ -116,19 +116,6 @@ def indel_count(row, cohort, filter_fn, normalized_per_mb, **kwargs):
         **kwargs)
 
 
-@count_function
-def missense_snv_count(row, cohort, filter_fn, normalized_per_mb, **kwargs):
-    def missense_filter_fn(filterable_effect, **kwargs):
-        assert filter_fn is not None, "filter_fn should never be None, but it is."
-        return (type(filterable_effect.effect) == Substitution and
-                filter_fn(filterable_effect, **kwargs))
-    # This only loads one effect per variant.
-    patient_id = row["patient_id"]
-    return cohort.load_effects(
-        only_nonsynonymous=True,
-        patients=[cohort.patient_from_id(patient_id)],
-        filter_fn=missense_filter_fn,
-        **kwargs)
 
 @count_function
 def effect_count(row, cohort, filter_fn, normalized_per_mb, **kwargs):

--- a/cohorts/functions.py
+++ b/cohorts/functions.py
@@ -182,6 +182,51 @@ def exonic_snv_count(row, cohort, filter_fn, normalized_per_mb, **kwargs):
         **kwargs)
 
 @count_function
+def exonic_silent_snv_count(row, cohort, filter_fn, normalized_per_mb, **kwargs):
+    def exonic_filter_fn(filterable_effect, **kwargs):
+        assert filter_fn is not None, "filter_fn should never be None, but it is."
+        return (isinstance(filterable_effect.effect, Exonic) and
+                filterable_effect.variant.is_snv and
+                filter_fn(filterable_effect, **kwargs))
+    # This only loads one effect per variant.
+    patient_id = row["patient_id"]
+    return cohort.load_effects(
+        only_nonsynonymous=False,
+        patients=[cohort.patient_from_id(patient_id)],
+        filter_fn=exonic_filter_fn,
+        **kwargs)
+
+@count_function
+def exonic_indel_count(row, cohort, filter_fn, normalized_per_mb, **kwargs):
+    def exonic_indel_filter_fn(filterable_effect, **kwargs):
+        assert filter_fn is not None, "filter_fn should never be None, but it is."
+        return (isinstance(filterable_effect.effect, Exonic) and
+                filterable_effect.variant.is_deletion and
+                filter_fn(filterable_effect, **kwargs))
+    # This only loads one effect per variant.
+    patient_id = row["patient_id"]
+    return cohort.load_effects(
+        only_nonsynonymous=True,
+        patients=[cohort.patient_from_id(patient_id)],
+        filter_fn=exonic_indel_filter_fn,
+        **kwargs)
+
+@count_function
+def exonic_insert_count(row, cohort, filter_fn, normalized_per_mb, **kwargs):
+    def exonic_insert_filter_fn(filterable_effect, **kwargs):
+        assert filter_fn is not None, "filter_fn should never be None, but it is."
+        return (isinstance(filterable_effect.effect, Exonic) and
+                filterable_effect.variant.is_insertion and
+                filter_fn(filterable_effect, **kwargs))
+    # This only loads one effect per variant.
+    patient_id = row["patient_id"]
+    return cohort.load_effects(
+        only_nonsynonymous=True,
+        patients=[cohort.patient_from_id(patient_id)],
+        filter_fn=exonic_insert_filter_fn,
+        **kwargs)
+
+@count_function
 def neoantigen_count(row, cohort, filter_fn, normalized_per_mb, **kwargs):
     patient = cohort.patient_from_id(row["patient_id"])
     return cohort.load_neoantigens(patients=[patient],
@@ -194,6 +239,16 @@ def expressed_missense_snv_count(row, cohort, filter_fn, normalized_per_mb, **kw
         assert filter_fn is not None, "filter_fn should never be None, but it is."
         return filter_fn(filterable_effect) and effect_expressed_filter(filterable_effect)
     return missense_snv_count(row=row,
+                              cohort=cohort,
+                              filter_fn=expressed_filter_fn,
+                              normalized_per_mb=normalized_per_mb, **kwargs)
+
+@use_defaults
+def expressed_exonic_snv_count(row, cohort, filter_fn, normalized_per_mb, **kwargs):
+    def expressed_filter_fn(filterable_effect, **kwargs):
+        assert filter_fn is not None, "filter_fn should never be None, but it is."
+        return filter_fn(filterable_effect) and effect_expressed_filter(filterable_effect)
+    return exonic_snv_count(row=row,
                               cohort=cohort,
                               filter_fn=expressed_filter_fn,
                               normalized_per_mb=normalized_per_mb, **kwargs)

--- a/cohorts/functions.py
+++ b/cohorts/functions.py
@@ -126,12 +126,16 @@ def effect_count(row, cohort, filter_fn, normalized_per_mb, **kwargs):
 
 @count_function
 def nonsynonymous_snv_count(row, cohort, filter_fn, normalized_per_mb, **kwargs):
+    def snv_filter_fn(filterable_effect, **kwargs):
+        assert filter_fn is not None, "filter_fn should never be None, but it is."
+        return (filterable_effect.variant.is_snv and
+                filter_fn(filterable_effect, **kwargs))
     # This only loads one effect per variant.
     patient_id = row["patient_id"]
     return cohort.load_effects(
         only_nonsynonymous=True,
         patients=[cohort.patient_from_id(patient_id)],
-        filter_fn=filter_fn,
+        filter_fn=snv_filter_fn,
         **kwargs)
 
 @count_function

--- a/cohorts/functions.py
+++ b/cohorts/functions.py
@@ -67,12 +67,37 @@ def get_patient_to_mb(cohort):
     patient_to_mb = dict(cohort.as_dataframe(join_with="ensembl_coverage")[["patient_id", "MB"]].to_dict("split")["data"])
     return patient_to_mb
 
+
 @count_function
-def snv_count(row, cohort, filter_fn, normalized_per_mb, **kwargs):
+def variant_count(row, cohort, filter_fn, normalized_per_mb, **kwargs):
     patient_id = row["patient_id"]
     return cohort.load_variants(
         patients=[cohort.patient_from_id(patient_id)],
         filter_fn=filter_fn,
+        **kwargs)
+
+@count_function
+def snv_count(row, cohort, filter_fn, normalized_per_mb, **kwargs):
+    patient_id = row["patient_id"]
+    def snv_filter_fn(filterable_variant, **kwargs):
+        assert filter_fn is not None, "filter_fn should never be None, but it is."
+        return (filterable_variant.variant.is_snv and
+                filter_fn(filterable_variant=filterable_variant, **kwargs))
+    return cohort.load_variants(
+        patients=[cohort.patient_from_id(patient_id)],
+        filter_fn=snv_filter_fn,
+        **kwargs)
+
+@count_function
+def indel_count(row, cohort, filter_fn, normalized_per_mb, **kwargs):
+    patient_id = row["patient_id"]
+    def indel_filter_fn(filterable_variant, **kwargs):
+        assert filter_fn is not None, "filter_fn should never be None, but it is."
+        return (filterable_variant.variant.is_indel and
+                filter_fn(filterable_variant=filterable_variant, **kwargs))
+    return cohort.load_variants(
+        patients=[cohort.patient_from_id(patient_id)],
+        filter_fn=indel_filter_fn,
         **kwargs)
 
 @count_function

--- a/cohorts/patient.py
+++ b/cohorts/patient.py
@@ -39,8 +39,6 @@ class Patient(object):
         Has the patient seen a durable clinical benefit?
     variants : str or VariantCollection or list
         VCF or MAF path, VariantCollection, or list of some combination of those.
-    indel_vcf_paths : list
-        List of paths to indel VCFs for this patient; multple VCFs get merged.
     normal_sample : Sample
         This patient's normal `Sample`.
     tumor_sample: Sample

--- a/cohorts/utils.py
+++ b/cohorts/utils.py
@@ -183,7 +183,7 @@ def get_logger(name, level=logging.INFO):
     logger = logging.getLogger(name)
     if logger.handlers:
         logger.handlers = []
-    stdout_handler = logging.StreamHandler(sys.stdout)
-    logger.addHandler(stdout_handler)
+    #stdout_handler = logging.StreamHandler(sys.stdout)
+    #logger.addHandler(stdout_handler)
     logger.setLevel(level)
     return logger

--- a/cohorts/utils.py
+++ b/cohorts/utils.py
@@ -183,7 +183,5 @@ def get_logger(name, level=logging.INFO):
     logger = logging.getLogger(name)
     if logger.handlers:
         logger.handlers = []
-    #stdout_handler = logging.StreamHandler(sys.stdout)
-    #logger.addHandler(stdout_handler)
     logger.setLevel(level)
     return logger

--- a/cohorts/utils.py
+++ b/cohorts/utils.py
@@ -179,11 +179,11 @@ def strip_column_names(cols, keep_paren_contents=True):
 
     return dict(zip(cols, new_cols))
 
-def get_logger(name):
+def get_logger(name, level=logging.INFO):
     logger = logging.getLogger(name)
     if logger.handlers:
         logger.handlers = []
     stdout_handler = logging.StreamHandler(sys.stdout)
     logger.addHandler(stdout_handler)
-    logger.setLevel(logging.INFO)
+    logger.setLevel(level)
     return logger

--- a/cohorts/varcode_utils.py
+++ b/cohorts/varcode_utils.py
@@ -90,7 +90,7 @@ def filter_variants(variant_collection, patient, filter_fn, **kwargs):
     else:
         return variant_collection
 
-def filter_effects(effect_collection, variant_collection, patient, filter_fn):
+def filter_effects(effect_collection, variant_collection, patient, filter_fn, **kwargs):
     """Filter variants from the Effect Collection
 
     Parameters
@@ -113,7 +113,7 @@ def filter_effects(effect_collection, variant_collection, patient, filter_fn):
             if filter_fn(FilterableEffect(
                     effect=effect,
                     variant_collection=variant_collection,
-                    patient=patient))])
+                    patient=patient), **kwargs)])
     else:
         return effect_collection
 

--- a/cohorts/varcode_utils.py
+++ b/cohorts/varcode_utils.py
@@ -62,7 +62,7 @@ class FilterablePolyphen(FilterableVariant):
                                    variant_collection=variant_collection,
                                    patient=patient)
 
-def filter_variants(variant_collection, patient, filter_fn):
+def filter_variants(variant_collection, patient, filter_fn, **kwargs):
     """Filter variants from the Variant Collection
 
     Parameters
@@ -82,9 +82,10 @@ def filter_variants(variant_collection, patient, filter_fn):
             variant
             for variant in variant_collection
             if filter_fn(FilterableVariant(
-                    variant=variant,
-                    variant_collection=variant_collection,
-                    patient=patient))
+                        variant=variant,
+                        variant_collection=variant_collection,
+                        patient=patient,
+                        ), **kwargs)
         ])
     else:
         return variant_collection

--- a/cohorts/variant_filters.py
+++ b/cohorts/variant_filters.py
@@ -18,6 +18,10 @@ from varcode import Variant
 from varcode.common import memoize
 import pandas as pd
 from os import path
+import logging
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
 
 def no_filter(filterable_variant):
     return True
@@ -28,6 +32,9 @@ def variant_qc_filter(filterable_variant,
                       min_tumor_vaf,
                       max_normal_vaf,
                       min_tumor_alt_depth):
+    
+    logger.debug('Applying variant_qc_filter with params: min_tumor_depth={}, min_normal_depth={}, min_tumor_vaf={}, max_normal_vaf={}, min_tumor_alt_depth={}'.format(min_tumor_depth, min_normal_depth, min_tumor_vaf, max_normal_vaf, min_tumor_alt_depth))
+    
     somatic_stats = variant_stats_from_variant(filterable_variant.variant,
                                                filterable_variant.variant_metadata)
 

--- a/cohorts/variant_filters.py
+++ b/cohorts/variant_filters.py
@@ -13,15 +13,14 @@
 # limitations under the License.
 
 from .variant_stats import variant_stats_from_variant
+from .utils import get_logger
 
 from varcode import Variant
 from varcode.common import memoize
 import pandas as pd
 from os import path
-import logging
 
-logger = logging.getLogger(__name__)
-logger.setLevel(logging.DEBUG)
+logger = get_logger(__name__)
 
 def no_filter(filterable_variant):
     return True

--- a/cohorts/variant_stats.py
+++ b/cohorts/variant_stats.py
@@ -1,5 +1,4 @@
 from collections import namedtuple
-import numpy as np
 
 VariantStats = namedtuple("VariantStats",
                           ["depth", "alt_depth", "variant_allele_frequency"])

--- a/cohorts/variant_stats.py
+++ b/cohorts/variant_stats.py
@@ -48,25 +48,22 @@ def _strelka_variant_stats(variant, sample_info):
     VariantStats
     """
     
-    try:
-        if variant.is_deletion or variant.is_insertion:
-            # ref: https://sites.google.com/site/strelkasomaticvariantcaller/home/somatic-variant-output
-            #depth = int(sample_info['DP']) # read depth for tier 1
-            ref_depth = int(sample_info['TAR'][0]) # number of reads supporting ref allele (non-deletion)
-            alt_depth = int(sample_info['TIR'][0]) # number of reads supporting alt allele (deletion)
-            depth = ref_depth + alt_depth
-        else:
-            # Retrieve the Tier 1 counts from Strelka
-            ref_depth = int(sample_info[variant.ref+"U"][0])
-            alt_depth = int(sample_info[variant.alt+"U"][0])
-            depth = alt_depth + ref_depth
-        if depth > 0:
-            vaf = float(alt_depth) / depth
-        else:
-            vaf = None
-    except:
-        import pdb
-        pdb.set_trace()
+    if variant.is_deletion or variant.is_insertion:
+        # ref: https://sites.google.com/site/strelkasomaticvariantcaller/home/somatic-variant-output
+        #depth = int(sample_info['DP']) # read depth for tier 1
+        # not sure why this depth is different from the sum of ref + alt
+        ref_depth = int(sample_info['TAR'][0]) # number of reads supporting ref allele (non-deletion)
+        alt_depth = int(sample_info['TIR'][0]) # number of reads supporting alt allele (deletion)
+        depth = ref_depth + alt_depth
+    else:
+        # Retrieve the Tier 1 counts from Strelka
+        ref_depth = int(sample_info[variant.ref+"U"][0])
+        alt_depth = int(sample_info[variant.alt+"U"][0])
+        depth = alt_depth + ref_depth
+    if depth > 0:
+        vaf = float(alt_depth) / depth
+    else:
+        vaf = None
 
     return VariantStats(depth=depth, alt_depth=alt_depth, variant_allele_frequency=vaf)
 

--- a/pylintrc
+++ b/pylintrc
@@ -2,4 +2,4 @@
 # Without ignoring this, we get errors like:
 # E:249,20: Module 'numpy' has no 'nan' member (no-member)
 ignored-modules = numpy, inspect
-ignored-classes = DataFrameHolder, TextFileReader, tuple, list, zip, izip
+ignored-classes = DataFrameHolder, TextFileReader, tuple, list, zip, izip, str

--- a/pylintrc
+++ b/pylintrc
@@ -2,4 +2,4 @@
 # Without ignoring this, we get errors like:
 # E:249,20: Module 'numpy' has no 'nan' member (no-member)
 ignored-modules = numpy, inspect
-ignored-classes = DataFrameHolder, TextFileReader, tuple, list, zip
+ignored-classes = DataFrameHolder, TextFileReader, tuple, list, zip, izip

--- a/pylintrc
+++ b/pylintrc
@@ -1,5 +1,5 @@
 [TYPECHECK]
 # Without ignoring this, we get errors like:
 # E:249,20: Module 'numpy' has no 'nan' member (no-member)
-ignored-modules = numpy
-ignored-classes = DataFrameHolder
+ignored-modules = numpy, inspect
+ignored-classes = DataFrameHolder, TextFileReader, tuple, list, zip

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,4 +17,4 @@ patsy>=0.4.1
 mock>=2.0.0
 serializable>=0.0.8
 dill>=0.2.5
-tqdm
+tqdm>=4.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ patsy>=0.4.1
 mock>=2.0.0
 serializable>=0.0.8
 dill>=0.2.5
+tqdm

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ patsy>=0.4.1
 mock>=2.0.0
 serializable>=0.0.8
 dill>=0.2.5
+logging

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ isovar==0.0.6
 patsy>=0.4.1
 mock>=2.0.0
 serializable>=0.0.8
+dill>=0.2.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,4 +17,3 @@ patsy>=0.4.1
 mock>=2.0.0
 serializable>=0.0.8
 dill>=0.2.5
-logging

--- a/test/test_cohort_defaults.py
+++ b/test/test_cohort_defaults.py
@@ -32,7 +32,7 @@ from .test_count import make_cohort
 
 FILE_FORMAT_1 = "patient_format1_%s.vcf"
 
-def test_default_filter_fn_with_variant_count():
+def test_default_filter_fn(summary_fn=variant_count):
     """
     Test that filter_fn falls back to the Cohort default but can be overridden.
     """
@@ -43,25 +43,25 @@ def test_default_filter_fn_with_variant_count():
 
         vcf_dir, cohort = make_cohort([FILE_FORMAT_1])
 
-        df = cohort.as_dataframe(variant_count)
+        cols, df = cohort.as_dataframe(summary_fn, return_cols=True)
         eq_(len(df), 3)
-        eq_(list(df["variant_count"]), [3, 3, 6])
+        eq_(list(df[cols[1]]), [3, 3, 6])
 
         cohort.filter_fn = default_filter_fn
-        df = cohort.as_dataframe(variant_count)
+        cols, df = cohort.as_dataframe(summary_fn, return_cols=True)
         eq_(len(df), 3)
-        eq_(list(df["variant_count"]), [2, 2, 5])
+        eq_(list(df[cols[1]]), [2, 2, 5])
 
-        df = cohort.as_dataframe(variant_count, filter_fn=None)
-        eq_(list(df["variant_count"]), [2, 2, 5])
+        cols, df = cohort.as_dataframe(summary_fn, filter_fn=None, return_cols=True)
+        eq_(list(df[cols[1]]), [2, 2, 5])
 
-        df = cohort.as_dataframe(variant_count, filter_fn=no_filter)
-        eq_(list(df["variant_count"]), [3, 3, 6])
+        cols, df = cohort.as_dataframe(summary_fn, filter_fn=no_filter, return_cols=True)
+        eq_(list(df[cols[1]]), [3, 3, 6])
 
         def another_filter_fn(filterable_variant):
             return default_filter_fn(filterable_variant) and filterable_variant.variant.start != 49658590
-        df = cohort.as_dataframe(variant_count, filter_fn=another_filter_fn)
-        eq_(list(df["variant_count"]), [1, 1, 4])
+        cols, df = cohort.as_dataframe(summary_fn, filter_fn=another_filter_fn, return_cols=True)
+        eq_(list(df[cols[1]]), [1, 1, 4])
     finally:
         if vcf_dir is not None and path.exists(vcf_dir):
             rmtree(vcf_dir)
@@ -73,37 +73,7 @@ def test_default_filter_fn_with_snv_count():
     """
     Test that filter_fn falls back to the Cohort default but can be overridden.
     """
-    vcf_dir, cohort = None, None
-    try:
-        def default_filter_fn(filterable_variant):
-            return filterable_variant.variant.start != 53513530
-
-        vcf_dir, cohort = make_cohort([FILE_FORMAT_1])
-
-        df = cohort.as_dataframe(snv_count)
-        eq_(len(df), 3)
-        eq_(list(df["snv_count"]), [3, 3, 6])
-
-        cohort.filter_fn = default_filter_fn
-        df = cohort.as_dataframe(snv_count)
-        eq_(len(df), 3)
-        eq_(list(df["snv_count"]), [2, 2, 5])
-
-        df = cohort.as_dataframe(snv_count, filter_fn=None)
-        eq_(list(df["snv_count"]), [2, 2, 5])
-
-        df = cohort.as_dataframe(snv_count, filter_fn=no_filter)
-        eq_(list(df["snv_count"]), [3, 3, 6])
-
-        def another_filter_fn(filterable_variant):
-            return default_filter_fn(filterable_variant) and filterable_variant.variant.start != 49658590
-        df = cohort.as_dataframe(snv_count, filter_fn=another_filter_fn)
-        eq_(list(df["snv_count"]), [1, 1, 4])
-    finally:
-        if vcf_dir is not None and path.exists(vcf_dir):
-            rmtree(vcf_dir)
-        if cohort is not None:
-            cohort.clear_caches()
+    test_default_filter_fn(snv_count)
 
             
 def test_default_normalized_per_mb():

--- a/test/test_cohort_defaults.py
+++ b/test/test_cohort_defaults.py
@@ -34,7 +34,7 @@ FILE_FORMAT_1 = "patient_format1_%s.vcf"
 
 def test_default_filter_fn(summary_fn=variant_count):
     """
-    Test that filter_fn falls back to the Cohort default but can be overridden.
+    Test that variant_count filter_fn falls back to the Cohort default but can be overridden.
     """
     vcf_dir, cohort = None, None
     try:
@@ -43,25 +43,25 @@ def test_default_filter_fn(summary_fn=variant_count):
 
         vcf_dir, cohort = make_cohort([FILE_FORMAT_1])
 
-        cols, df = cohort.as_dataframe(summary_fn, return_cols=True)
+        col, df = cohort.as_dataframe(summary_fn, return_cols=True)
         eq_(len(df), 3)
-        eq_(list(df[cols[1]]), [3, 3, 6])
+        eq_(list(df[col]), [3, 3, 6])
 
         cohort.filter_fn = default_filter_fn
-        cols, df = cohort.as_dataframe(summary_fn, return_cols=True)
+        col, df = cohort.as_dataframe(summary_fn, return_cols=True)
         eq_(len(df), 3)
-        eq_(list(df[cols[1]]), [2, 2, 5])
+        eq_(list(df[col]), [2, 2, 5])
 
-        cols, df = cohort.as_dataframe(summary_fn, filter_fn=None, return_cols=True)
-        eq_(list(df[cols[1]]), [2, 2, 5])
+        col, df = cohort.as_dataframe(summary_fn, filter_fn=None, return_cols=True)
+        eq_(list(df[col]), [2, 2, 5])
 
-        cols, df = cohort.as_dataframe(summary_fn, filter_fn=no_filter, return_cols=True)
-        eq_(list(df[cols[1]]), [3, 3, 6])
+        col, df = cohort.as_dataframe(summary_fn, filter_fn=no_filter, return_cols=True)
+        eq_(list(df[col]), [3, 3, 6])
 
         def another_filter_fn(filterable_variant):
             return default_filter_fn(filterable_variant) and filterable_variant.variant.start != 49658590
-        cols, df = cohort.as_dataframe(summary_fn, filter_fn=another_filter_fn, return_cols=True)
-        eq_(list(df[cols[1]]), [1, 1, 4])
+        col, df = cohort.as_dataframe(summary_fn, filter_fn=another_filter_fn, return_cols=True)
+        eq_(list(df[col]), [1, 1, 4])
     finally:
         if vcf_dir is not None and path.exists(vcf_dir):
             rmtree(vcf_dir)
@@ -71,7 +71,7 @@ def test_default_filter_fn(summary_fn=variant_count):
             
 def test_default_filter_fn_with_snv_count():
     """
-    Test that filter_fn falls back to the Cohort default but can be overridden.
+    Test that snv_count filter_fn (which using closure) falls back to the Cohort default but can be overridden.
     """
     test_default_filter_fn(snv_count)
 


### PR DESCRIPTION
This is an updated version of another PR - #168

Notes from that PR:

1. Addresses issues #166 - variant stats lead to divide by zero error when total read count is 0 for a variant
2. Also addresses #167 - filtering variant stats by type, irrespective of merged file type
3. caches filtered variants as well as unfiltered variant collections
4. pass **kwargs to filter_fn, if provided. This enables more flexible filtering 

Also now includes PR #171:

1. Clean up some issues in filtered-variants cache, namely:
    - inspect closure of filter_fn for other filter_fns, use these to name the cached file
    - ^ above method only works for python3; skip filtered cache on py2
    - added some tests to identify issues in the above
2. Made things more robust to errors reading from cache - e.g. fix #170  
    - skip reading from cache if there is any error
3. added a number of new summary functions to `cohorts.functions`, including `exonic_snv_count`, `expressed_exonic_snv_count`, etc.
3. functions named 'snv' now explicitly filter for `.is_snv` type
4. pass **kwargs through summary functions to filter functions; e.g. for functions like `variant_qc_filter`, so that the following works for `as_dataframe` & `plot_benefit`, etc.:

    ```
    df = cohort.as_dataframe(
            on=[exonic_snv_count],
            filter_fn=cohorts.variant_filters.variant_qc_filter,
            min_tumor_depth=7,
            min_normal_depth=7,
            min_tumor_vaf=0.1,
            max_normal_vaf=0.03,
            min_tumor_alt_depth=0)
    ```
5. allow **kwargs use with multiple functions, e.g. so the above can be multiplexed:
    ```
    df = cohort.as_dataframe(
            on=[exonic_snv_count, missense_snv_count, expressed_missense_snv_count],
            filter_fn=cohorts.variant_filters.variant_qc_filter,
            min_tumor_depth=7,
            min_normal_depth=7,
            min_tumor_vaf=0.1,
            max_normal_vaf=0.03,
            min_tumor_alt_depth=0)
    ```
    This will print a "warning" statement that the kwargs are passed to all functions, in lieu of previous behavior which resulted in an error.
7. Added debug logging statements throughout load-variants & application of filter functions to test behavior.
8. Added progress bar printing progress of function-application, to better know if process is running or stalled. 
    - modified logging to not use stdout, so that progress bars print correctly.

    Output looks like:
    ![screen shot 2016-12-21 at 2 08 07 pm](https://cloud.githubusercontent.com/assets/923453/21402534/f0f12bac-c786-11e6-8f44-7e1972ef4b41.png)

