### PR TITLE
Add exonic count functions

### DIFF
--- a/cohorts/cohort.py
+++ b/cohorts/cohort.py
@@ -506,6 +506,7 @@ class Cohort(Collection):
     def _hash_filter_fn(self, filter_fn, **kwargs):
         if filter_fn is None:
             return 'filter-none'
+        filter_fn_name = filter_fn.__name__
         logger.debug('Computing hash for filter_fn: {} with kwargs {}'.format(filter_fn_name, str(dict(**kwargs))))
         # function source code
         fn_source = str(dill.source.getsource(filter_fn))

--- a/cohorts/cohort.py
+++ b/cohorts/cohort.py
@@ -484,7 +484,7 @@ class Cohort(Collection):
             merged_variants = self.load_from_cache(self.cache_names["variant"], patient.id, variant_cache_file_name)
             variant_collections = list()
             if merged_variants is None:
-                vcf_paths = patient.vcf_paths
+                vcf_paths = patient.snv_vcf_paths
                 variant_collections = [
                     varcode.load_vcf_fast(vcf_path)
                     for vcf_path in vcf_paths

--- a/cohorts/cohort.py
+++ b/cohorts/cohort.py
@@ -499,14 +499,14 @@ class Cohort(Collection):
         failed_io = False
         try:
             ## try to load filtered variants from cache
-            filtered_cache_file_name = "%s-%s-variants.filter-%s.pkl" % (self.variant_type, self.merge_type,
+            filtered_cache_file_name = "%s-variants.filter-%s.pkl" % (self.merge_type,
                                                                  self._hash_filter_fn(filter_fn, **kwargs))
             cached = self.load_from_cache(self.cache_names["variant"], patient.id, filtered_cache_file_name)
             if cached is not None:
                 return cached
             
             ## load unfiltered variants into list of collections
-            variant_cache_file_name = "%s-%s-variants.pkl" % (self.variant_type, self.merge_type)
+            variant_cache_file_name = "%s-variants.pkl" % (self.merge_type)
             merged_variants = self.load_from_cache(self.cache_names["variant"], patient.id, variant_cache_file_name)
             variant_collections = []
             if merged_variants is None:

--- a/cohorts/cohort.py
+++ b/cohorts/cohort.py
@@ -26,6 +26,7 @@ import dill
 import hashlib
 import inspect
 import sys
+import logging
 
 # pylint doesn't like this line
 # pylint: disable=no-name-in-module
@@ -59,6 +60,8 @@ from .varcode_utils import (filter_variants, filter_effects,
 from .variant_filters import no_filter
 from .styling import set_styling
 from . import variant_filters
+
+logger = logging.getLogger(__name__)
 
 class Cohort(Collection):
     """

--- a/cohorts/cohort.py
+++ b/cohorts/cohort.py
@@ -47,6 +47,7 @@ from isovar.protein_sequence import variants_to_protein_sequences_dataframe
 from pysam import AlignmentFile
 from scipy.stats import pearsonr
 from collections import defaultdict
+from tqdm import tqdm
 
 from .dataframe_loader import DataFrameLoader
 from .utils import DataFrameHolder, first_not_none_param, filter_not_null, InvalidDataError, strip_column_names as _strip_column_names, get_logger
@@ -326,7 +327,8 @@ class Cohort(Collection):
                 func = lambda row: on(row=row, **kwargs)
             else:
                 func = lambda row: on(row=row, cohort=self, **kwargs)
-            df[col] = df.apply(func, axis=1)
+            tqdm.pandas(desc=col)
+            df[col] = df.progress_apply(func, axis=1)
             return DataFrameHolder(col, df)
 
         def func_name(func, num=0):

--- a/cohorts/cohort.py
+++ b/cohorts/cohort.py
@@ -402,7 +402,7 @@ class Cohort(Collection):
     def load_from_cache(self, cache_name, patient_id, file_name):
         if not self.cache_results:
             return None
-
+        
         cache_dir = path.join(self.cache_dir, cache_name)
         patient_cache_dir = path.join(cache_dir, str(patient_id))
         cache_file = path.join(patient_cache_dir, file_name)
@@ -421,12 +421,14 @@ class Cohort(Collection):
                 left_outer_diff = "In current environment but not cached in %s for patient %s" % (cache_name, patient_id),
                 right_outer_diff = "In cached %s for patient %s but not current" % (cache_name, patient_id)
                 )
-
-        if path.splitext(cache_file)[1] == ".csv":
-            return pd.read_csv(cache_file, dtype={"patient_id": object})
-        else:
-            with open(cache_file, "rb") as f:
-                return pickle.load(f)
+        try:
+            if path.splitext(cache_file)[1] == ".csv":
+                return pd.read_csv(cache_file, dtype={"patient_id": object})
+            else:
+                with open(cache_file, "rb") as f:
+                    return pickle.load(f)
+        except:
+            return None
 
     def save_to_cache(self, obj, cache_name, patient_id, file_name):
         if not self.cache_results:

--- a/cohorts/cohort.py
+++ b/cohorts/cohort.py
@@ -729,7 +729,7 @@ class Cohort(Collection):
                                filter_fn=filter_fn)
 
     def load_effects(self, patients=None, only_nonsynonymous=False,
-                     all_effects=False, filter_fn=None):
+                     all_effects=False, filter_fn=None, **kwargs):
         """Load a dictionary of patient_id to varcode.EffectCollection
 
         Note that this only loads one effect per variant.
@@ -761,12 +761,12 @@ class Cohort(Collection):
         patient_effects = {}
         for patient in self.iter_patients(patients):
             effects = self._load_single_patient_effects(
-                patient, only_nonsynonymous, all_effects, filter_fn)
+                patient, only_nonsynonymous, all_effects, filter_fn, **kwargs)
             if effects is not None:
                 patient_effects[patient.id] = effects
         return patient_effects
 
-    def _load_single_patient_effects(self, patient, only_nonsynonymous, all_effects, filter_fn):
+    def _load_single_patient_effects(self, patient, only_nonsynonymous, all_effects, filter_fn, **kwargs):
         cached_file_name = "%s-effects.pkl" % self.merge_type
         if filter_fn is None:
             filter_fn_name = 'None'
@@ -793,7 +793,8 @@ class Cohort(Collection):
             return filter_effects(effect_collection=cached,
                                   variant_collection=variants,
                                   patient=patient,
-                                  filter_fn=filter_fn)
+                                  filter_fn=filter_fn,
+                                 **kwargs)
 
         effects = variants.effects()
 
@@ -813,7 +814,8 @@ class Cohort(Collection):
                 nonsynonymous_effects if only_nonsynonymous else effects),
             variant_collection=variants,
             patient=patient,
-            filter_fn=filter_fn)
+            filter_fn=filter_fn,
+            **kwargs)
 
     def load_kallisto(self):
         """

--- a/cohorts/functions.py
+++ b/cohorts/functions.py
@@ -79,10 +79,10 @@ def variant_count(row, cohort, filter_fn, normalized_per_mb, **kwargs):
 
 @count_function
 def exonic_variant_count(row, cohort, filter_fn, normalized_per_mb, **kwargs):
-    def exonic_filter_fn(filterable_effect):
+    def exonic_filter_fn(filterable_effect, **kwargs):
         assert filter_fn is not None, "filter_fn should never be None, but it is."
         return (isinstance(filterable_effect.effect, Exonic) and
-                filter_fn(filterable_effect))
+                filter_fn(filterable_effect, **kwargs))
     # This only loads one effect per variant.
     patient_id = row["patient_id"]
     return cohort.load_effects(
@@ -118,10 +118,10 @@ def indel_count(row, cohort, filter_fn, normalized_per_mb, **kwargs):
 
 @count_function
 def missense_snv_count(row, cohort, filter_fn, normalized_per_mb, **kwargs):
-    def missense_filter_fn(filterable_effect):
+    def missense_filter_fn(filterable_effect, **kwargs):
         assert filter_fn is not None, "filter_fn should never be None, but it is."
         return (type(filterable_effect.effect) == Substitution and
-                filter_fn(filterable_effect))
+                filter_fn(filterable_effect, **kwargs))
     # This only loads one effect per variant.
     patient_id = row["patient_id"]
     return cohort.load_effects(
@@ -153,11 +153,11 @@ def nonsynonymous_snv_count(row, cohort, filter_fn, normalized_per_mb, **kwargs)
 
 @count_function
 def missense_snv_count(row, cohort, filter_fn, normalized_per_mb, **kwargs):
-    def missense_filter_fn(filterable_effect):
+    def missense_filter_fn(filterable_effect, **kwargs):
         assert filter_fn is not None, "filter_fn should never be None, but it is."
         return (type(filterable_effect.effect) == Substitution and
                 filterable_effect.variant.is_snv and
-                filter_fn(filterable_effect))
+                filter_fn(filterable_effect, **kwargs))
     # This only loads one effect per variant.
     patient_id = row["patient_id"]
     return cohort.load_effects(
@@ -168,11 +168,11 @@ def missense_snv_count(row, cohort, filter_fn, normalized_per_mb, **kwargs):
 
 @count_function
 def exonic_snv_count(row, cohort, filter_fn, normalized_per_mb, **kwargs):
-    def exonic_filter_fn(filterable_effect):
+    def exonic_filter_fn(filterable_effect, **kwargs):
         assert filter_fn is not None, "filter_fn should never be None, but it is."
         return (isinstance(filterable_effect.effect, Exonic) and
                 filterable_effect.variant.is_snv and
-                filter_fn(filterable_effect))
+                filter_fn(filterable_effect, **kwargs))
     # This only loads one effect per variant.
     patient_id = row["patient_id"]
     return cohort.load_effects(
@@ -190,13 +190,13 @@ def neoantigen_count(row, cohort, filter_fn, normalized_per_mb, **kwargs):
 
 @use_defaults
 def expressed_missense_snv_count(row, cohort, filter_fn, normalized_per_mb, **kwargs):
-    def expressed_filter_fn(filterable_effect):
+    def expressed_filter_fn(filterable_effect, **kwargs):
         assert filter_fn is not None, "filter_fn should never be None, but it is."
         return filter_fn(filterable_effect) and effect_expressed_filter(filterable_effect)
     return missense_snv_count(row=row,
                               cohort=cohort,
                               filter_fn=expressed_filter_fn,
-                              normalized_per_mb=normalized_per_mb)
+                              normalized_per_mb=normalized_per_mb, **kwargs)
 
 @use_defaults
 def expressed_neoantigen_count(row, cohort, filter_fn, normalized_per_mb, **kwargs):

--- a/cohorts/functions.py
+++ b/cohorts/functions.py
@@ -78,6 +78,20 @@ def variant_count(row, cohort, filter_fn, normalized_per_mb, **kwargs):
         **kwargs)
 
 @count_function
+def exonic_variant_count(row, cohort, filter_fn, normalized_per_mb, **kwargs):
+    def exonic_filter_fn(filterable_effect):
+        assert filter_fn is not None, "filter_fn should never be None, but it is."
+        return (isinstance(filterable_effect.effect, Exonic) and
+                filter_fn(filterable_effect))
+    # This only loads one effect per variant.
+    patient_id = row["patient_id"]
+    return cohort.load_effects(
+        only_nonsynonymous=False,
+        patients=[cohort.patient_from_id(patient_id)],
+        filter_fn=exonic_filter_fn,
+        **kwargs)
+
+@count_function
 def snv_count(row, cohort, filter_fn, normalized_per_mb, **kwargs):
     patient_id = row["patient_id"]
     def snv_filter_fn(filterable_variant, **kwargs):
@@ -164,7 +178,7 @@ def exonic_snv_count(row, cohort, filter_fn, normalized_per_mb, **kwargs):
     return cohort.load_effects(
         only_nonsynonymous=True,
         patients=[cohort.patient_from_id(patient_id)],
-        filter_fn=missense_filter_fn,
+        filter_fn=exonic_filter_fn,
         **kwargs)
 
 @count_function

--- a/cohorts/functions.py
+++ b/cohorts/functions.py
@@ -116,19 +116,6 @@ def indel_count(row, cohort, filter_fn, normalized_per_mb, **kwargs):
         **kwargs)
 
 
-@count_function
-def missense_snv_count(row, cohort, filter_fn, normalized_per_mb, **kwargs):
-    def missense_filter_fn(filterable_effect, **kwargs):
-        assert filter_fn is not None, "filter_fn should never be None, but it is."
-        return (type(filterable_effect.effect) == Substitution and
-                filter_fn(filterable_effect, **kwargs))
-    # This only loads one effect per variant.
-    patient_id = row["patient_id"]
-    return cohort.load_effects(
-        only_nonsynonymous=True,
-        patients=[cohort.patient_from_id(patient_id)],
-        filter_fn=missense_filter_fn,
-        **kwargs)
 
 @count_function
 def effect_count(row, cohort, filter_fn, normalized_per_mb, **kwargs):

--- a/cohorts/functions.py
+++ b/cohorts/functions.py
@@ -182,6 +182,51 @@ def exonic_snv_count(row, cohort, filter_fn, normalized_per_mb, **kwargs):
         **kwargs)
 
 @count_function
+def exonic_silent_snv_count(row, cohort, filter_fn, normalized_per_mb, **kwargs):
+    def exonic_filter_fn(filterable_effect, **kwargs):
+        assert filter_fn is not None, "filter_fn should never be None, but it is."
+        return (isinstance(filterable_effect.effect, Exonic) and
+                filterable_effect.variant.is_snv and
+                filter_fn(filterable_effect, **kwargs))
+    # This only loads one effect per variant.
+    patient_id = row["patient_id"]
+    return cohort.load_effects(
+        only_nonsynonymous=False,
+        patients=[cohort.patient_from_id(patient_id)],
+        filter_fn=exonic_filter_fn,
+        **kwargs)
+
+@count_function
+def exonic_indel_count(row, cohort, filter_fn, normalized_per_mb, **kwargs):
+    def exonic_indel_filter_fn(filterable_effect, **kwargs):
+        assert filter_fn is not None, "filter_fn should never be None, but it is."
+        return (isinstance(filterable_effect.effect, Exonic) and
+                filterable_effect.variant.is_deletion and
+                filter_fn(filterable_effect, **kwargs))
+    # This only loads one effect per variant.
+    patient_id = row["patient_id"]
+    return cohort.load_effects(
+        only_nonsynonymous=True,
+        patients=[cohort.patient_from_id(patient_id)],
+        filter_fn=exonic_indel_filter_fn,
+        **kwargs)
+
+@count_function
+def exonic_insert_count(row, cohort, filter_fn, normalized_per_mb, **kwargs):
+    def exonic_insert_filter_fn(filterable_effect, **kwargs):
+        assert filter_fn is not None, "filter_fn should never be None, but it is."
+        return (isinstance(filterable_effect.effect, Exonic) and
+                filterable_effect.variant.is_insertion and
+                filter_fn(filterable_effect, **kwargs))
+    # This only loads one effect per variant.
+    patient_id = row["patient_id"]
+    return cohort.load_effects(
+        only_nonsynonymous=True,
+        patients=[cohort.patient_from_id(patient_id)],
+        filter_fn=exonic_insert_filter_fn,
+        **kwargs)
+
+@count_function
 def neoantigen_count(row, cohort, filter_fn, normalized_per_mb, **kwargs):
     patient = cohort.patient_from_id(row["patient_id"])
     return cohort.load_neoantigens(patients=[patient],
@@ -194,6 +239,16 @@ def expressed_missense_snv_count(row, cohort, filter_fn, normalized_per_mb, **kw
         assert filter_fn is not None, "filter_fn should never be None, but it is."
         return filter_fn(filterable_effect) and effect_expressed_filter(filterable_effect)
     return missense_snv_count(row=row,
+                              cohort=cohort,
+                              filter_fn=expressed_filter_fn,
+                              normalized_per_mb=normalized_per_mb, **kwargs)
+
+@use_defaults
+def expressed_exonic_snv_count(row, cohort, filter_fn, normalized_per_mb, **kwargs):
+    def expressed_filter_fn(filterable_effect, **kwargs):
+        assert filter_fn is not None, "filter_fn should never be None, but it is."
+        return filter_fn(filterable_effect) and effect_expressed_filter(filterable_effect)
+    return exonic_snv_count(row=row,
                               cohort=cohort,
                               filter_fn=expressed_filter_fn,
                               normalized_per_mb=normalized_per_mb, **kwargs)

--- a/cohorts/functions.py
+++ b/cohorts/functions.py
@@ -67,12 +67,37 @@ def get_patient_to_mb(cohort):
     patient_to_mb = dict(cohort.as_dataframe(join_with="ensembl_coverage")[["patient_id", "MB"]].to_dict("split")["data"])
     return patient_to_mb
 
+
 @count_function
-def snv_count(row, cohort, filter_fn, normalized_per_mb, **kwargs):
+def variant_count(row, cohort, filter_fn, normalized_per_mb, **kwargs):
     patient_id = row["patient_id"]
     return cohort.load_variants(
         patients=[cohort.patient_from_id(patient_id)],
         filter_fn=filter_fn,
+        **kwargs)
+
+@count_function
+def snv_count(row, cohort, filter_fn, normalized_per_mb, **kwargs):
+    patient_id = row["patient_id"]
+    def snv_filter_fn(filterable_variant, **kwargs):
+        assert filter_fn is not None, "filter_fn should never be None, but it is."
+        return (filterable_variant.variant.is_snv and
+                filter_fn(filterable_variant=filterable_variant, **kwargs))
+    return cohort.load_variants(
+        patients=[cohort.patient_from_id(patient_id)],
+        filter_fn=snv_filter_fn,
+        **kwargs)
+
+@count_function
+def indel_count(row, cohort, filter_fn, normalized_per_mb, **kwargs):
+    patient_id = row["patient_id"]
+    def indel_filter_fn(filterable_variant, **kwargs):
+        assert filter_fn is not None, "filter_fn should never be None, but it is."
+        return (filterable_variant.variant.is_indel and
+                filter_fn(filterable_variant=filterable_variant, **kwargs))
+    return cohort.load_variants(
+        patients=[cohort.patient_from_id(patient_id)],
+        filter_fn=indel_filter_fn,
         **kwargs)
 
 @count_function

--- a/cohorts/patient.py
+++ b/cohorts/patient.py
@@ -39,8 +39,6 @@ class Patient(object):
         Has the patient seen a durable clinical benefit?
     variants : str or VariantCollection or list
         VCF or MAF path, VariantCollection, or list of some combination of those.
-    indel_vcf_paths : list
-        List of paths to indel VCFs for this patient; multple VCFs get merged.
     normal_sample : Sample
         This patient's normal `Sample`.
     tumor_sample: Sample

--- a/cohorts/utils.py
+++ b/cohorts/utils.py
@@ -183,7 +183,7 @@ def get_logger(name, level=logging.INFO):
     logger = logging.getLogger(name)
     if logger.handlers:
         logger.handlers = []
-    stdout_handler = logging.StreamHandler(sys.stdout)
-    logger.addHandler(stdout_handler)
+    #stdout_handler = logging.StreamHandler(sys.stdout)
+    #logger.addHandler(stdout_handler)
     logger.setLevel(level)
     return logger

--- a/cohorts/utils.py
+++ b/cohorts/utils.py
@@ -179,11 +179,11 @@ def strip_column_names(cols, keep_paren_contents=True):
 
     return dict(zip(cols, new_cols))
 
-def get_logger(name):
+def get_logger(name, level=logging.INFO):
     logger = logging.getLogger(name)
     if logger.handlers:
         logger.handlers = []
     stdout_handler = logging.StreamHandler(sys.stdout)
     logger.addHandler(stdout_handler)
-    logger.setLevel(logging.INFO)
+    logger.setLevel(level)
     return logger

--- a/cohorts/varcode_utils.py
+++ b/cohorts/varcode_utils.py
@@ -90,7 +90,7 @@ def filter_variants(variant_collection, patient, filter_fn, **kwargs):
     else:
         return variant_collection
 
-def filter_effects(effect_collection, variant_collection, patient, filter_fn):
+def filter_effects(effect_collection, variant_collection, patient, filter_fn, **kwargs):
     """Filter variants from the Effect Collection
 
     Parameters
@@ -113,7 +113,7 @@ def filter_effects(effect_collection, variant_collection, patient, filter_fn):
             if filter_fn(FilterableEffect(
                     effect=effect,
                     variant_collection=variant_collection,
-                    patient=patient))])
+                    patient=patient), **kwargs)])
     else:
         return effect_collection
 

--- a/cohorts/varcode_utils.py
+++ b/cohorts/varcode_utils.py
@@ -62,7 +62,7 @@ class FilterablePolyphen(FilterableVariant):
                                    variant_collection=variant_collection,
                                    patient=patient)
 
-def filter_variants(variant_collection, patient, filter_fn):
+def filter_variants(variant_collection, patient, filter_fn, **kwargs):
     """Filter variants from the Variant Collection
 
     Parameters
@@ -82,9 +82,10 @@ def filter_variants(variant_collection, patient, filter_fn):
             variant
             for variant in variant_collection
             if filter_fn(FilterableVariant(
-                    variant=variant,
-                    variant_collection=variant_collection,
-                    patient=patient))
+                        variant=variant,
+                        variant_collection=variant_collection,
+                        patient=patient,
+                        ), **kwargs)
         ])
     else:
         return variant_collection

--- a/cohorts/variant_filters.py
+++ b/cohorts/variant_filters.py
@@ -18,6 +18,10 @@ from varcode import Variant
 from varcode.common import memoize
 import pandas as pd
 from os import path
+import logging
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
 
 def no_filter(filterable_variant):
     return True
@@ -28,6 +32,9 @@ def variant_qc_filter(filterable_variant,
                       min_tumor_vaf,
                       max_normal_vaf,
                       min_tumor_alt_depth):
+    
+    logger.debug('Applying variant_qc_filter with params: min_tumor_depth={}, min_normal_depth={}, min_tumor_vaf={}, max_normal_vaf={}, min_tumor_alt_depth={}'.format(min_tumor_depth, min_normal_depth, min_tumor_vaf, max_normal_vaf, min_tumor_alt_depth))
+    
     somatic_stats = variant_stats_from_variant(filterable_variant.variant,
                                                filterable_variant.variant_metadata)
 

--- a/cohorts/variant_filters.py
+++ b/cohorts/variant_filters.py
@@ -13,15 +13,14 @@
 # limitations under the License.
 
 from .variant_stats import variant_stats_from_variant
+from .utils import get_logger
 
 from varcode import Variant
 from varcode.common import memoize
 import pandas as pd
 from os import path
-import logging
 
-logger = logging.getLogger(__name__)
-logger.setLevel(logging.DEBUG)
+logger = get_logger(__name__)
 
 def no_filter(filterable_variant):
     return True

--- a/pylintrc
+++ b/pylintrc
@@ -2,4 +2,4 @@
 # Without ignoring this, we get errors like:
 # E:249,20: Module 'numpy' has no 'nan' member (no-member)
 ignored-modules = numpy, inspect
-ignored-classes = DataFrameHolder, TextFileReader, tuple, list, zip, izip
+ignored-classes = DataFrameHolder, TextFileReader, tuple, list, zip, izip, str

--- a/pylintrc
+++ b/pylintrc
@@ -2,4 +2,4 @@
 # Without ignoring this, we get errors like:
 # E:249,20: Module 'numpy' has no 'nan' member (no-member)
 ignored-modules = numpy, inspect
-ignored-classes = DataFrameHolder, TextFileReader, tuple, list, zip
+ignored-classes = DataFrameHolder, TextFileReader, tuple, list, zip, izip

--- a/pylintrc
+++ b/pylintrc
@@ -1,5 +1,5 @@
 [TYPECHECK]
 # Without ignoring this, we get errors like:
 # E:249,20: Module 'numpy' has no 'nan' member (no-member)
-ignored-modules = numpy
-ignored-classes = DataFrameHolder
+ignored-modules = numpy, inspect
+ignored-classes = DataFrameHolder, TextFileReader, tuple, list, zip

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ patsy>=0.4.1
 mock>=2.0.0
 serializable>=0.0.8
 dill>=0.2.5
+tqdm

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ patsy>=0.4.1
 mock>=2.0.0
 serializable>=0.0.8
 dill>=0.2.5
+logging

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ isovar==0.0.6
 patsy>=0.4.1
 mock>=2.0.0
 serializable>=0.0.8
+dill>=0.2.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,4 +17,3 @@ patsy>=0.4.1
 mock>=2.0.0
 serializable>=0.0.8
 dill>=0.2.5
-logging


### PR DESCRIPTION
Modifications:

1. Clean up some issues in filtered-variants cache, namely:
    - inspect closure of filter_fn for other filter_fns, use these to name the cached file
    - ^ above method only works for python3; skip filtered cache on py2
    - added some tests to identify issues in the above
2. Made things more robust to errors reading from cache - e.g. fix #170  
    - skip reading from cache if there is any error
3. added a number of new summary functions to `cohorts.functions`, including `exonic_snv_count`, `expressed_exonic_snv_count`, etc.
3. functions named 'snv' now explicitly filter for `.is_snv` type
4. pass **kwargs through summary functions to filter functions; e.g. for functions like `variant_qc_filter`, so that the following works for `as_dataframe` & `plot_benefit`, etc.:

    ```
    df = cohort.as_dataframe(
            on=[exonic_snv_count],
            filter_fn=cohorts.variant_filters.variant_qc_filter,
            min_tumor_depth=7,
            min_normal_depth=7,
            min_tumor_vaf=0.1,
            max_normal_vaf=0.03,
            min_tumor_alt_depth=0)
    ```
5. allow **kwargs use with multiple functions, e.g. so the above can be multiplexed:
    ```
    df = cohort.as_dataframe(
            on=[exonic_snv_count, missense_snv_count, expressed_missense_snv_count],
            filter_fn=cohorts.variant_filters.variant_qc_filter,
            min_tumor_depth=7,
            min_normal_depth=7,
            min_tumor_vaf=0.1,
            max_normal_vaf=0.03,
            min_tumor_alt_depth=0)
    ```
    This will print a "warning" statement that the kwargs are passed to all functions, in lieu of previous behavior which resulted in an error.
7. Added debug logging statements throughout load-variants & application of filter functions to test behavior.
8. Added progress bar printing progress of function-application, to better know if process is running or stalled. 
    - modified logging to not use stdout, so that progress bars print correctly.

    Output looks like:
    ![screen shot 2016-12-21 at 2 08 07 pm](https://cloud.githubusercontent.com/assets/923453/21402534/f0f12bac-c786-11e6-8f44-7e1972ef4b41.png)
