### PR TITLE
Upgrade isovar to the latest version in cohorts

### DIFF
--- a/cohorts/functions.py
+++ b/cohorts/functions.py
@@ -120,4 +120,7 @@ def expressed_missense_snv_count(row, cohort, filter_fn, normalized_per_mb, **kw
 def expressed_neoantigen_count(row, cohort, filter_fn, normalized_per_mb, **kwargs):
     return neoantigen_count(row=row,
                             cohort=cohort,
-                            only_expressed=True, **kwargs)
+                            filter_fn=filter_fn,
+                            normalized_per_mb=normalized_per_mb,
+                            only_expressed=True,
+                            **kwargs)

--- a/cohorts/variant_filters.py
+++ b/cohorts/variant_filters.py
@@ -49,7 +49,9 @@ def variant_qc_filter(filterable_variant,
     return True
 
 @memoize
-def expressed_variant_set(patient, variant_collection):
+def expressed_variant_set(cohort, patient, variant_collection):
+    # Warning: we previously had an issue where we used the same
+    # memoized set across different cohorts.
     # TODO: we're currently using the same isovar cache that we use for expressed
     # neoantigen prediction; so we pass in the same epitope lengths.
     # This is hacky and should be addressed.
@@ -69,6 +71,7 @@ def expressed_variant_set(patient, variant_collection):
 
 def variant_expressed_filter(filterable_variant, **kwargs):
     expressed_variants = expressed_variant_set(
+        cohort=filterable_variant.patient.cohort,
         patient=filterable_variant.patient,
         variant_collection=filterable_variant.variant_collection)
     return filterable_variant.variant in expressed_variants

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ vcf-annotate-polyphen>=0.1.2
 nose>=1.3.3
 pylint>=1.4.4
 scikit-bio==0.4.2
-isovar==0.0.6
+isovar>=0.5.2
 patsy>=0.4.1
 mock>=2.0.0
 serializable>=0.0.8


### PR DESCRIPTION
In this PR:
* Upgrade isovar from 0.0.6 to the latest version
* Fix `expressed_neoantigen_count` to pass `normalized_per_mb` and `filter_fn` through; this shouldn't have impacted our analyses unless we ever passed in a `filter_fn` directly into `expressed_neoantigen_count` (versus using the cohort-level default).
* Fix `expressed_variant_set` memoizing such that it memoizes per-cohort (ran into an issue where I had two `Cohort`s and it was sharing the value.

This could use some tests; filed https://github.com/hammerlab/cohorts/issues/176

FYI @iskandr in case you see anything wonky