### PR TITLE
Refactor and fix functions

### DIFF
--- a/cohorts/cohort.py
+++ b/cohorts/cohort.py
@@ -341,8 +341,6 @@ class Cohort(Collection):
         if type(on) == FunctionType:
             return apply_func(on, func_name(on), df).return_self(return_cols)
 
-        # For multiple functions, don't allow kwargs since we won't know which functions
-        # they apply to.
         if len(kwargs) > 0:
             logger.warning("Note: kwargs used with multiple functions; passing them to all functions")
 
@@ -405,7 +403,7 @@ class Cohort(Collection):
     def load_from_cache(self, cache_name, patient_id, file_name):
         if not self.cache_results:
             return None
-        
+
         logger.debug("loading patient {} data from {} cache: {}".format(patient_id, cache_name, file_name))
 
         cache_dir = path.join(self.cache_dir, cache_name)
@@ -442,7 +440,7 @@ class Cohort(Collection):
     def save_to_cache(self, obj, cache_name, patient_id, file_name):
         if not self.cache_results:
             return
-        
+
         logger.debug("saving patient {} data to {} cache: {}".format(patient_id, cache_name, file_name))
 
         cache_dir = path.join(self.cache_dir, cache_name)
@@ -481,7 +479,7 @@ class Cohort(Collection):
         else:
             fn_name = fn.__name__
         return fn_name
-    
+
     def load_variants(self, patients=None, filter_fn=None, **kwargs):
         """Load a dictionary of patient_id to varcode.VariantCollection
 
@@ -540,14 +538,14 @@ class Cohort(Collection):
                               closure]
                             )
         return hashed_fn
-    
+
     def _load_single_patient_variants(self, patient, filter_fn, use_cache=True, **kwargs):
         """ Load filtered, merged variants for a single patient, optionally using cache
-        
-            Note that filtered variants are first merged before filtering, and 
+
+            Note that filtered variants are first merged before filtering, and
                 each step is cached independently. Turn on debug statements for more
                 details about cached files.
-                
+
             Use `_load_single_patient_merged_variants` to see merged variants without filtering.
         """
         filter_fn_name = self._get_function_name(filter_fn)
@@ -556,7 +554,7 @@ class Cohort(Collection):
         if sys.version_info < (3, 3):
             logger.info("... disabling filtered cache due to python version")
             use_filtered_cache = False
-            
+
         ## confirm that we can get cache-name (else don't use filtered cache)
         if use_filtered_cache:
             logger.debug("... identifying filtered-cache file name")
@@ -577,7 +575,7 @@ class Cohort(Collection):
                 except:
                     logger.warning("Error loading variants from cache for patient: {}".format(patient.id))
                     pass
-        
+
         ## get merged variants
         logger.debug("... getting merged variants for: {}".format(patient.id))
         merged_variants = self._load_single_patient_merged_variants(patient, use_cache=use_cache)
@@ -586,7 +584,7 @@ class Cohort(Collection):
         if merged_variants is None:
             logger.info("Variants did not exist for patient %s" % patient.id)
             return None
-        
+
         logger.debug("... applying filters to variants for: {}".format(patient.id))
         filtered_variants = filter_variants(variant_collection=merged_variants,
                                             patient=patient,
@@ -596,11 +594,11 @@ class Cohort(Collection):
             logger.debug("... saving filtered variants to cache: {}".format(filtered_cache_file_name))
             self.save_to_cache(filtered_variants, self.cache_names["variant"], patient.id, filtered_cache_file_name)
         return filtered_variants
-    
+
     def _load_single_patient_merged_variants(self, patient, use_cache=True):
         """ Load merged variants for a single patient, optionally using cache
-        
-            Note that merged variants are not filtered. 
+
+            Note that merged variants are not filtered.
             Use `_load_single_patient_variants` to get filtered variants
         """
         logger.debug("loading merged variants for patient {}".format(patient.id))
@@ -648,12 +646,12 @@ class Cohort(Collection):
         if no_variants:
             print("Variants did not exist for patient %s" % patient.id)
             merged_variants = None
-        
+
         # save merged variants to file
         if use_cache:
             self.save_to_cache(merged_variants, self.cache_names["variant"], patient.id, variant_cache_file_name)
         return merged_variants
-    
+
     def _merge_variant_collections(self, variant_collections, merge_type):
         logger.debug("Merging variants using merge type: {}".format(merge_type))
         assert merge_type in ["union", "intersection"], "Unknown merge type: %s" % merge_type

--- a/cohorts/functions.py
+++ b/cohorts/functions.py
@@ -69,6 +69,12 @@ def get_patient_to_mb(cohort):
     return patient_to_mb
 
 def count_variants_function_builder(function_name, filterable_variant_function=None):
+    """
+    Creates a function that counts variants that are filtered by the provided filterable_variant_function.
+    The filterable_variant_function is a function that takes a filterable_variant and returns True or False.
+
+    Users of this builder need not worry about applying e.g. the Cohort's default `filter_fn`. That will be applied as well.
+    """
     @count_function
     def count(row, cohort, filter_fn, normalized_per_mb, **kwargs):
         def count_filter_fn(filterable_variant, **kwargs):
@@ -84,6 +90,12 @@ def count_variants_function_builder(function_name, filterable_variant_function=N
     return count
 
 def count_effects_function_builder(function_name, only_nonsynonymous, filterable_effect_function=None):
+    """
+    Create a function that counts effects that are filtered by the provided filterable_effect_function.
+    The filterable_effect_function is a function that takes a filterable_effect and returns True or False.
+
+    Users of this builder need not worry about applying e.g. the Cohort's default `filter_fn`. That will be applied as well.
+    """
     @count_function
     def count(row, cohort, filter_fn, normalized_per_mb, **kwargs):
         def count_filter_fn(filterable_effect, **kwargs):

--- a/cohorts/functions.py
+++ b/cohorts/functions.py
@@ -22,6 +22,7 @@ import numpy as np
 from varcode.effects import Substitution
 from varcode.common import memoize
 from varcode.effects.effect_classes import Exonic
+import inspect
 
 def use_defaults(func):
     """
@@ -87,6 +88,7 @@ def count_variants_function_builder(function_name, filterable_variant_function=N
             filter_fn=count_filter_fn,
             **kwargs)
     count.__name__ = function_name
+    count.__doc__ = str("".join(inspect.getsourcelines(filterable_variant_function)[0])) if filterable_variant_function is not None else ""
     return count
 
 def count_effects_function_builder(function_name, only_nonsynonymous, filterable_effect_function=None):
@@ -110,6 +112,8 @@ def count_effects_function_builder(function_name, only_nonsynonymous, filterable
             filter_fn=count_filter_fn,
             **kwargs)
     count.__name__ = function_name
+    count.__doc__ = (("only_nonsynonymous=%s\n" % only_nonsynonymous) +
+                     str("".join(inspect.getsourcelines(filterable_effect_function)[0])) if filterable_effect_function is not None else "")
     return count
 
 variant_count = count_variants_function_builder("variant_count")


### PR DESCRIPTION
In this PR:

* Added `count_effects_function_builder` and `count_variants_function_builder` to get rid of a bunch of boilerplate.
* Tried to make our functions consistent. For example, if a function is counting nonsynonymous mutations, that should be clear in the title (where I think `missense` is clearly a subset). I renamed `exonic_insertion_count` and `exonic_deletion_count` to `nonsynonymous_insertion_count` and `nonsynonymous_deletion_count`, since exonic is implied when we're talking about nonsynonymous mutations, and those functions had `only_nonsynonymous=True`.
   * On a related note: does this mean that our exonic SNV counts in the bladder paper are actually nonsynonymous mutation counts? Maybe not, since https://github.com/hammerlab/bladder-analyses/blob/e6a48c04d4d49a1af10fe89e1b563731440ae841/analyses/utils/extra_functions.py#L4 doesn't appear to filter by nonsynonymous?
* Added more functions.
   * New `exonic_` functions that act differently: `only_nonsynonymous=False`, so that they're not just nonsynonymous mutations.
   * Renamed `exonic_silent_snv_count` to just `exonic_snv_count`, per the above (and https://github.com/hammerlab/cohorts/issues/181).
   * Added `indel_count`, `insertion_count`, `deletion_count`; including fixing the existing `deletion_count` (https://github.com/hammerlab/cohorts/issues/182).
* Tried to add unit tests to compare new vs. old, but it got unwieldy. Instead, I just made a notebook where I copied all the old functions and compared with the new counterparts: https://github.com/hammerlab/msk-bms-lung/blob/master/analyses/notebooks/Test%20New%20Count%20Functions.ipynb

Also fixes https://github.com/hammerlab/cohorts/issues/184