### PR TITLE
Update Pageant logic

### DIFF
--- a/cohorts/cohort.py
+++ b/cohorts/cohort.py
@@ -543,6 +543,7 @@ class Cohort(Collection):
             ## capture hash for any function within closure
             if inspect.isfunction(val):
                 closure.append(self._hash_filter_fn(val))
+        closure.sort() # Sorted for file name consistency
         closure_str = "null" if len(closure) == 0 else "-".join(closure)
         # construct final string comprising hashed components
         hashed_fn = ".".join(["-".join([filter_fn_name,

--- a/cohorts/cohort.py
+++ b/cohorts/cohort.py
@@ -537,17 +537,18 @@ class Cohort(Collection):
         else:
             [kw_hash.append("{}-{}".format(key, h)) for (key, h) in sorted(kw_dict.items())]
         # hash closure vars - for case where filter_fn is defined within closure of filter_fn
-        closure = "null"
+        closure = []
         nonlocals = inspect.getclosurevars(filter_fn).nonlocals
         for (key, val) in nonlocals.items():
             ## capture hash for any function within closure
             if inspect.isfunction(val):
-                closure = "{}-{}".format(filter_fn_name, self._hash_filter_fn(val))
+                closure.append(self._hash_filter_fn(val))
+        closure_str = "null" if len(closure) == 0 else "-".join(closure)
         # construct final string comprising hashed components
         hashed_fn = ".".join(["-".join([filter_fn_name,
                                         str(hashed_fn_source)]),
                               ".".join(kw_hash),
-                              closure]
+                              closure_str]
                             )
         return hashed_fn
 

--- a/cohorts/cohort.py
+++ b/cohorts/cohort.py
@@ -109,6 +109,8 @@ class Cohort(Collection):
         Path to a Polyphen database dump.
     pageant_coverage_path : str
         Path to Pageant CoverageDepth output.
+    pageant_dir_fn : function
+        Function from patient to a specific Pageant CoverageDepth directory within the path. Defaults to the Patietn ID.
     benefit_plot_name : str
         What word to use for "benefit" when plotting.
     merge_type : {"union", "intersection"}, optional
@@ -133,6 +135,7 @@ class Cohort(Collection):
                  print_filter=True,
                  polyphen_dump_path=None,
                  pageant_coverage_path=None,
+                 pageant_dir_fn=None,
                  benefit_plot_name="Benefit",
                  merge_type="union"):
         Collection.__init__(
@@ -164,6 +167,7 @@ class Cohort(Collection):
         self.check_provenance = check_provenance
         self.polyphen_dump_path = polyphen_dump_path
         self.pageant_coverage_path = pageant_coverage_path
+        self.pageant_dir_fn = pageant_dir_fn
         self.benefit_plot_name = benefit_plot_name
         self.merge_type = merge_type
         self._genome = None
@@ -1109,7 +1113,8 @@ class Cohort(Collection):
             cohort=self,
             coverage_path=self.pageant_coverage_path,
             min_normal_depth=self.min_coverage_normal_depth,
-            min_tumor_depth=self.min_coverage_tumor_depth)
+            min_tumor_depth=self.min_coverage_tumor_depth,
+            pageant_dir_fn=self.pageant_dir_fn)
 
     def clear_caches(self):
         for cache in self.cache_names.keys():

--- a/cohorts/varcode_utils.py
+++ b/cohorts/varcode_utils.py
@@ -123,7 +123,10 @@ def filter_neoantigens(neoantigens_df, variant_collection, patient, filter_fn):
             lambda row: filter_fn(
                 FilterableNeoantigen(neoantigen_row=row,
                                      variant_collection=variant_collection,
-                                     patient=patient)), axis=1)
+                                     patient=patient)),
+            axis=1,
+            # reduce ensures that an empty result is a Series vs. a DataFrame
+            reduce=True)
         return neoantigens_df[filter_mask]
     else:
         return neoantigens_df
@@ -134,7 +137,10 @@ def filter_polyphen(polyphen_df, variant_collection, patient, filter_fn):
             lambda row: filter_fn(
                 FilterablePolyphen(polyphen_row=row,
                                    variant_collection=variant_collection,
-                                   patient=patient)), axis=1)
+                                   patient=patient)),
+            axis=1,
+            # reduce ensures that an empty result is a Series vs. a DataFrame
+            reduce=True)
         return polyphen_df[filter_mask]
     else:
         return polyphen_df

--- a/cohorts/variant_filters.py
+++ b/cohorts/variant_filters.py
@@ -84,7 +84,7 @@ def variant_expressed_filter(filterable_variant, **kwargs):
 def effect_expressed_filter(filterable_effect, **kwargs):
     return variant_expressed_filter(filterable_effect, **kwargs)
 
-def load_ensembl_coverage(cohort, coverage_path, min_tumor_depth, min_normal_depth=None,
+def load_ensembl_coverage(cohort, coverage_path, min_tumor_depth, min_normal_depth=0,
                           pageant_dir_fn=None):
     """
     Load in Pageant CoverageDepth results with Ensembl loci.
@@ -92,7 +92,7 @@ def load_ensembl_coverage(cohort, coverage_path, min_tumor_depth, min_normal_dep
     coverage_path is a path to Pageant CoverageDepth output directory, with
     one subdirectory per patient and a `cdf.csv` file inside each patient subdir.
 
-    If min_normal_depth is None, calculate tumor coverage. Otherwise, calculate
+    If min_normal_depth is 0, calculate tumor coverage. Otherwise, calculate
     join tumor/normal coverage.
 
     pageant_dir_fn is a function that takes in a Patient and produces a Pageant


### PR DESCRIPTION
Allow for single-sample or tumor/normal coverage, and update columns/etc. to the latest Pageant format. Allow the Pageant output file folder names to be specified as functions of the `Patient`.