### PR TITLE
Require Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 sudo: false  # Use container-based infrastructure
 language: python
 python:
+  - "3.3"
   - "3.4"
+  - "3.6"
 env:
   # Use a non-interactive backend to avoid PyQt4 install issues, and because
   # we don't need interactivity in Travis.

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_install:
 install:
   - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy nose pandas matplotlib
   - source activate test-environment
-  - conda install -c bioconda pysam=0.9.0
+  - conda install -c bioconda pysam>=0.9.0
   - conda install -c conda-forge pypandoc
   - pip install -r requirements.txt
   - pip install .

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false  # Use container-based infrastructure
 language: python
 python:
-  - "2.7"
   - "3.4"
 env:
   # Use a non-interactive backend to avoid PyQt4 install issues, and because
@@ -11,11 +10,7 @@ before_install:
   # Commands below copied from: http://conda.pydata.org/docs/travis.html
   # We do this conditionally because it saves us some downloading if the
   # version is the same.
-  - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
-      wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh;
-    else
-      wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
-    fi
+  - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"
   # reset the shell's lookup table for program name to path mappings

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false  # Use container-based infrastructure
 language: python
 python:
-  - "3.3"
   - "3.4"
   - "3.6"
 env:

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Cohorts is a library for analyzing and plotting clinical data, mutations and neo
 
 It calls out to external libraries like [topiary](https://github.com/hammerlab/topiary) and caches the results for easy manipulation.
 
+Cohorts requires Python 3. We are no longer maintaining compatability with Python 2. For context, see this [Python 3 statement](www.python3statement.org).
+
 Installation
 ------------
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Cohorts is a library for analyzing and plotting clinical data, mutations and neo
 
 It calls out to external libraries like [topiary](https://github.com/hammerlab/topiary) and caches the results for easy manipulation.
 
-Cohorts requires Python 3. We are no longer maintaining compatability with Python 2. For context, see this [Python 3 statement](www.python3statement.org).
+Cohorts requires Python 3 (3.3+). We are no longer maintaining compatability with Python 2. For context, see this [Python 3 statement](www.python3statement.org).
 
 Installation
 ------------

--- a/cohorts/__init__.py
+++ b/cohorts/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016. Mount Sinai School of Medicine
+# Copyright (c) 2017. Mount Sinai School of Medicine
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/cohorts/cohort.py
+++ b/cohorts/cohort.py
@@ -23,7 +23,6 @@ from copy import copy
 import dill
 import hashlib
 import inspect
-import sys
 import logging
 
 # pylint doesn't like this line
@@ -573,9 +572,6 @@ class Cohort(Collection):
             filter_fn_name = self._get_function_name(filter_fn)
             logger.debug("loading variants for patient {} with filter_fn {}".format(patient.id, filter_fn_name))
             use_filtered_cache = use_cache
-            if sys.version_info < (3, 3):
-                logger.info("... disabling filtered cache due to python version")
-                use_filtered_cache = False
 
         ## confirm that we can get cache-name (else don't use filtered cache)
         if use_filtered_cache:

--- a/cohorts/cohort.py
+++ b/cohorts/cohort.py
@@ -24,6 +24,7 @@ import dill
 import hashlib
 import inspect
 import logging
+import pickle
 
 # pylint doesn't like this line
 # pylint: disable=no-name-in-module

--- a/cohorts/cohort.py
+++ b/cohorts/cohort.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016. Mount Sinai School of Medicine
+# Copyright (c) 2017. Mount Sinai School of Medicine
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,8 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-from __future__ import print_function
 
 from os import path, makedirs
 from shutil import rmtree
@@ -30,7 +28,6 @@ import logging
 
 # pylint doesn't like this line
 # pylint: disable=no-name-in-module
-import six.moves.cPickle as pickle
 from types import FunctionType
 
 import vap  ## vcf-annotate-polyphen

--- a/cohorts/collection.py
+++ b/cohorts/collection.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016. Mount Sinai School of Medicine
+# Copyright (c) 2017. Mount Sinai School of Medicine
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/cohorts/dataframe_loader.py
+++ b/cohorts/dataframe_loader.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016. Mount Sinai School of Medicine
+# Copyright (c) 2017. Mount Sinai School of Medicine
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,8 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-from __future__ import print_function
 
 class DataFrameLoader(object):
     """

--- a/cohorts/functions.py
+++ b/cohorts/functions.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016. Mount Sinai School of Medicine
+# Copyright (c) 2017. Mount Sinai School of Medicine
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,8 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-from __future__ import print_function
 
 from .variant_filters import no_filter, effect_expressed_filter
 from .varcode_utils import FilterableVariant

--- a/cohorts/model.py
+++ b/cohorts/model.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016. Mount Sinai School of Medicine
+# Copyright (c) 2017. Mount Sinai School of Medicine
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 from types import FunctionType
 import numpy as np
 import pandas as pd

--- a/cohorts/patient.py
+++ b/cohorts/patient.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016. Mount Sinai School of Medicine
+# Copyright (c) 2017. Mount Sinai School of Medicine
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,8 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-from __future__ import print_function
 
 from .utils import require_id_str, set_attributes
 

--- a/cohorts/plot.py
+++ b/cohorts/plot.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016. Mount Sinai School of Medicine
+# Copyright (c) 2017. Mount Sinai School of Medicine
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 from collections import namedtuple
 
 from scipy.stats import mannwhitneyu, fisher_exact

--- a/cohorts/provenance.py
+++ b/cohorts/provenance.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016. Mount Sinai School of Medicine
+# Copyright (c) 2017. Mount Sinai School of Medicine
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,8 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-from __future__ import print_function
 
 import warnings
 

--- a/cohorts/random.py
+++ b/cohorts/random.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016. Mount Sinai School of Medicine
+# Copyright (c) 2017. Mount Sinai School of Medicine
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,8 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-from __future__ import print_function
 
 import pandas as pd
 from os import path

--- a/cohorts/rounding.py
+++ b/cohorts/rounding.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016. Mount Sinai School of Medicine
+# Copyright (c) 2017. Mount Sinai School of Medicine
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/cohorts/sample.py
+++ b/cohorts/sample.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016. Mount Sinai School of Medicine
+# Copyright (c) 2017. Mount Sinai School of Medicine
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,8 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-from __future__ import print_function
 
 from .utils import set_attributes
 

--- a/cohorts/styling.py
+++ b/cohorts/styling.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016. Mount Sinai School of Medicine
+# Copyright (c) 2017. Mount Sinai School of Medicine
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,8 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-from __future__ import print_function
 
 import matplotlib as mpl
 import matplotlib.colors as colors

--- a/cohorts/survival.py
+++ b/cohorts/survival.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2016. Mount Sinai School of Medicine
+# Copyright (c) 2017. Mount Sinai School of Medicine
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,8 +13,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-from __future__ import print_function
 
 from lifelines import KaplanMeierFitter
 from lifelines.statistics import logrank_test

--- a/cohorts/utils.py
+++ b/cohorts/utils.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016. Mount Sinai School of Medicine
+# Copyright (c) 2017. Mount Sinai School of Medicine
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,14 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
-
 import re
 import warnings
 from collections import namedtuple
 import sys
 import logging
-from six import string_types
 
 class DataFrameHolder(namedtuple("DataFrameHolder", ["cols", "df"])):
     """Holds a DataFrame along with associated columns of interest."""
@@ -58,7 +55,7 @@ def filter_not_null(df, col):
     return df
 
 def require_id_str(id):
-    if not isinstance(id, string_types):
+    if type(id) != str:
         raise ValueError("Expected ID string, but id = {}".format(id))
 
 def _strip_column_name(col_name, keep_paren_contents=True):

--- a/cohorts/varcode_utils.py
+++ b/cohorts/varcode_utils.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2017. Mount Sinai School of Medicine
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from varcode import EffectCollection, Variant
 
 def genome(variant_collection):

--- a/cohorts/variant_filters.py
+++ b/cohorts/variant_filters.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016. Mount Sinai School of Medicine
+# Copyright (c) 2017. Mount Sinai School of Medicine
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/cohorts/variant_stats.py
+++ b/cohorts/variant_stats.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2017. Mount Sinai School of Medicine
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from collections import namedtuple
 
 VariantStats = namedtuple("VariantStats",

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ mock>=2.0.0
 serializable>=0.0.8
 dill>=0.2.5
 tqdm>=4.10.0
+pysam>=0.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ topiary>=0.1.0, <0.2.0
 mhctools>=0.3.0, <0.4.0
 varcode>=0.5.15, <0.6.0
 pyensembl>=1.0.1, <1.1.0
-six>=1.10.0
 lifelines>=0.9.1.0
 scikit-learn>=0.17.1
 vcf-annotate-polyphen>=0.1.2

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016. Mount Sinai School of Medicine
+# Copyright (c) 2017. Mount Sinai School of Medicine
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ if __name__ == "__main__":
         ],
         install_requires=install_requires,
         dependency_links=dependency_links,
-        python_requires=">=3",
+        python_requires=">=3.3",
         long_description=readme,
         packages=["cohorts"],
     )

--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,7 @@ if __name__ == "__main__":
         ],
         install_requires=install_requires,
         dependency_links=dependency_links,
+        python_requires=">=3",
         long_description=readme,
         packages=["cohorts"],
     )


### PR DESCRIPTION
No longer support Python 2, including:
* No longer test with Python 2.
* No longer use compatibility layers for Py2/3.
* Remove version checking logic.
* Clarify on README.
* Add `python_requires` constraint in `setup.py`.

Also update 2016 to 2017 in files.

I figured we should go all out and not allow Python 2 usage at all if we're no longer testing with Python 2. Otherwise, issues like `str` vs. `unicode` resulting in the wrong number of patients in the `Cohort` will be highly likely.