### PR TITLE
Plot surv by strata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ ENV.sh
 generated/
 .idea/
 cohorts.egg-info/
+.Rproj.user

--- a/cohorts/cohort.py
+++ b/cohorts/cohort.py
@@ -1320,7 +1320,7 @@ class Cohort(Collection):
         survival_units : str
             Unit of time for the survival measure, i.e. Days or Months
         strata : str
-            column name of stratifying variable
+            (optional) column name of stratifying variable
         ci_show : bool
             Display the confidence interval around the survival curve
         threshold : int or "median", optional
@@ -1340,57 +1340,25 @@ class Cohort(Collection):
             default_threshold = None
         else:
             default_threshold = "median"
-        if strata is None:
-            results = plot_kmf(
-                df=df,
-                condition_col=plot_col,
-                xlabel=survival_units,
-                ylabel="Overall Survival (%)" if how == "os" else "Progression-Free Survival (%)",
-                censor_col="deceased" if how == "os" else "progressed_or_deceased",
-                survival_col=how,
-                threshold=threshold if threshold is not None else default_threshold,
-                ax=ax,
-                ci_show=ci_show,
-                with_condition_color=with_condition_color,
-                no_condition_color=no_condition_color,
-                with_condition_label=with_condition_label,
-                no_condition_label=no_condition_label,
-                color_palette=color_palette,
-                label_map=label_map,
-                color_map=color_map,
-            )
-        else:
-            results = dict()
-            n_strata = len(df[strata].unique())
-            if ax is None:
-                f, ax = plt.subplots(n_strata, sharex=True)
-            a = 0
-            for strat, strat_df in df.groupby(strata):
-                if n_strata == 1:
-                    my_axis = ax
-                else:
-                    my_axis = ax[a]
-                title = "{}: {}".format(strata, strat)
-                print(title)
-                results[title] = plot_kmf(df=strat_df,
-                                        condition_col=plot_col,
-                                        xlabel=survival_units,
-                                        ylabel="Overall Survival (%)" if how == "os" else "Progression-Free Survival (%)",
-                                        censor_col="deceased" if how == "os" else "progressed_or_deceased",
-                                        survival_col=how,
-                                        threshold=threshold if threshold is not None else default_threshold,
-                                        ax=my_axis,
-                                        ci_show=ci_show,
-                                        with_condition_color=with_condition_color,
-                                        no_condition_color=no_condition_color,
-                                        with_condition_label=with_condition_label,
-                                        no_condition_label=no_condition_label,
-                                        color_palette=color_palette,
-                                        label_map=label_map,
-                                        color_map=color_map,
-                                        )
-                my_axis.set_title(title)
-                a += 1
+        results = plot_kmf(
+            df=df,
+            condition_col=plot_col,
+            xlabel=survival_units,
+            ylabel="Overall Survival (%)" if how == "os" else "Progression-Free Survival (%)",
+            censor_col="deceased" if how == "os" else "progressed_or_deceased",
+            survival_col=how,
+            strata_col=strata,
+            threshold=threshold if threshold is not None else default_threshold,
+            ax=ax,
+            ci_show=ci_show,
+            with_condition_color=with_condition_color,
+            no_condition_color=no_condition_color,
+            with_condition_label=with_condition_label,
+            no_condition_label=no_condition_label,
+            color_palette=color_palette,
+            label_map=label_map,
+            color_map=color_map,
+        )
         return results
 
     def plot_correlation(self, on, x_col=None, plot_type="jointplot", stat_func=pearsonr, show_stat_func=True, plot_kwargs={}, **kwargs):

--- a/cohorts/cohort.py
+++ b/cohorts/cohort.py
@@ -1360,7 +1360,7 @@ class Cohort(Collection):
                 color_map=color_map,
             )
         else:
-            results = list()
+            results = dict()
             n_strata = len(df[strata].unique())
             if ax is None:
                 f, ax = plt.subplots(n_strata, sharex=True)
@@ -1370,7 +1370,9 @@ class Cohort(Collection):
                     my_axis = ax
                 else:
                     my_axis = ax[a]
-                results.append(plot_kmf(df=strat_df,
+                title = "{}: {}".format(strata, strat)
+                print(title)
+                results[title] = plot_kmf(df=strat_df,
                                         condition_col=plot_col,
                                         xlabel=survival_units,
                                         ylabel="Overall Survival (%)" if how == "os" else "Progression-Free Survival (%)",
@@ -1386,8 +1388,8 @@ class Cohort(Collection):
                                         color_palette=color_palette,
                                         label_map=label_map,
                                         color_map=color_map,
-                                        ))
-                my_axis.set_title("{}: {}".format(strata, strat))
+                                        )
+                my_axis.set_title(title)
                 a += 1
         return results
 

--- a/cohorts/cohort.py
+++ b/cohorts/cohort.py
@@ -1322,23 +1322,13 @@ class Cohort(Collection):
             (optional) column name of stratifying variable
         ci_show : bool
             Display the confidence interval around the survival curve
-        threshold : int or "median", optional
+        threshold : int, "median", "median-per-strata" or None (optional)
             Threshold of `col` on which to split the cohort
         """
         assert how in ["os", "pfs"], "Invalid choice of survival plot type %s" % how
         cols, df = self.as_dataframe(on, return_cols=True, **kwargs)
         plot_col = self.plot_col_from_cols(cols=cols, only_allow_one=True)
         df = filter_not_null(df, plot_col)
-        if df[plot_col].dtype == "bool":
-            default_threshold = None
-        elif np.issubdtype(df[plot_col].dtype, np.number):
-            default_threshold = "median"
-        elif df[plot_col].dtype == "O": # is string
-            default_threshold = None
-        elif df[plot_col].dtype.name == "category":
-            default_threshold = None
-        else:
-            default_threshold = "median"
         results = plot_kmf(
             df=df,
             condition_col=plot_col,
@@ -1347,7 +1337,7 @@ class Cohort(Collection):
             censor_col="deceased" if how == "os" else "progressed_or_deceased",
             survival_col=how,
             strata_col=strata,
-            threshold=threshold if threshold is not None else default_threshold,
+            threshold=threshold,
             ax=ax,
             ci_show=ci_show,
             with_condition_color=with_condition_color,

--- a/cohorts/cohort.py
+++ b/cohorts/cohort.py
@@ -26,7 +26,6 @@ import inspect
 import logging
 import pickle
 import numpy as np
-from matplotlib import pyplot as plt
 
 # pylint doesn't like this line
 # pylint: disable=no-name-in-module

--- a/cohorts/survival.py
+++ b/cohorts/survival.py
@@ -167,6 +167,8 @@ def plot_kmf(df,
                                grp_survival_data[grp_names[1]],
                                event_observed_A=grp_event_data[grp_names[0]],
                                event_observed_B=grp_event_data[grp_names[1]])
+    elif len(grp_names) == 1:
+        results = NullSurvivalResults()
     else:
         cf = CoxPHFitter()
         cox_df = patsy.dmatrix('+'.join([condition_col, survival_col,
@@ -179,6 +181,9 @@ def plot_kmf(df,
     results.event_data_series = grp_event_data
     return results
 
+
+class NullSurvivalResults(object):
+    pass
 
 def logrank(df,
             condition_col,

--- a/cohorts/survival.py
+++ b/cohorts/survival.py
@@ -16,6 +16,7 @@
 
 from lifelines import KaplanMeierFitter, CoxPHFitter
 from lifelines.statistics import logrank_test
+import logging
 import matplotlib.colors as colors
 from matplotlib import pyplot as plt
 import numbers

--- a/cohorts/survival.py
+++ b/cohorts/survival.py
@@ -21,7 +21,6 @@ from matplotlib import pyplot as plt
 import seaborn as sb
 import patsy
 from .rounding import float_str
-import inspect
 
 def plot_kmf(df,
              condition_col,

--- a/cohorts/survival.py
+++ b/cohorts/survival.py
@@ -18,105 +18,44 @@ from lifelines import KaplanMeierFitter, CoxPHFitter
 from lifelines.statistics import logrank_test
 import matplotlib.colors as colors
 from matplotlib import pyplot as plt
+import numpy as np
 import seaborn as sb
 import patsy
 from .rounding import float_str
 
-def plot_kmf(df,
-             condition_col,
-             censor_col,
-             survival_col,
-             strata_col=None,
-             threshold=None,
-             title=None,
-             xlabel=None,
-             ylabel=None,
-             ax=None,
-             with_condition_color="#B38600",
-             no_condition_color="#A941AC",
-             with_condition_label=None,
-             no_condition_label=None,
-             color_map=None,
-             label_map=None,
-             color_palette="Set1",
-             ci_show=False,
-             print_as_title=False):
+
+def _plot_kmf_single(df,
+                     condition_col,
+                     survival_col,
+                     censor_col,
+                     threshold,
+                     title,
+                     xlabel,
+                     ylabel,
+                     ax,
+                     with_condition_color,
+                     no_condition_color,
+                     with_condition_label,
+                     no_condition_label,
+                     color_map,
+                     label_map,
+                     color_palette,
+                     ci_show,
+                     print_as_title):
     """
-    Plot survival curves by splitting the dataset into two groups based on
-    condition_col
+    Helper function to produce a single KM survival plot, among observations in df by groups defined by condition_col.
 
-    if threshold is defined, the groups are split based on being > or <
-    condition_col
-
-    if threshold == 'median', the threshold is set to the median of condition_col
-
-    Parameters
-    ----------
-        df: dataframe
-        condition_col: string, column which contains the condition to split on
-        survival_col: string, column which contains the survival time
-        censor_col: string,
-        strata_col: optional string, denoting column containing data to
-                    stratify by (default: None)
-        threshold: int or string, if int, condition_col is thresholded,
-                                  if 'median', condition_col thresholded
-                                  at its median
-        title: Title for the plot, default None
-        ax: an existing matplotlib ax, optional, default None
-             note: not currently supported when `strata_col` is not None
-        with_condition_color: str, hex code color for the with-condition curve
-        no_condition_color: str, hex code color for the no-condition curve
-        with_condition_label: str, optional, label for TRUE condition case
-        no_condition_label: str, optional, label for FALSE condition case
-        color_map: dict, optional, mapping of hex-values to condition text
-          in the form of {value_name: color_hex_code}.
-          defaults to `sb.color_palette` using `default_color_palette` name,
-          or *_condition_color options in case of boolean operators.
-        label_map: dict, optional, mapping of labels to condition text.
-          defaults to "condition_name = condition_value", or *_condition_label
-          options in case of boolean operators.
-        color_palette: str, optional, name of sb.color_palette to use
-          if color_map not provided.
-        print_as_title: bool, optional, whether or not to print text
-          within the plot's title vs. stdout, default False
+    All inputs are required - this function is intended to be called by `plot_kmf`.
     """
-    # if strata not None, call plot_kmf for each of the strata
-    if strata_col:
-        # want this at the top of the function!
-        arglist = locals() ## save input args for reuse
-        # create axis / subplots
-        if ax is not None:
-            raise ValueError('ax not supported with stratified analysis.')
-        n_strata = len(df[strata_col].unique())
-        f, ax = plt.subplots(n_strata, sharex=True)
-        a = 0 ## index for ax
-        # create results dict to hold per-strata results
-        results = dict()
-        # update strata_col to be None for each sub-call
-        arglist['strata_col'] = None
-        # call plot_kmf for each strata, using same args
-        for strat_name, strat_df in df.groupby(strata_col):
-            if n_strata == 1:
-                arglist['ax'] = ax
-            else:
-                arglist['ax'] = ax[a]
-            subtitle = "{}: {}".format(strata_col, strat_name)
-            arglist['title'] = subtitle
-            arglist['df'] = strat_df
-            print(subtitle) ## print a header, since plot_kmf prints results
-            results[subtitle] = plot_kmf(**arglist)
-            [print(desc) for desc in results[subtitle].desc]
-            a += 1
-        if title:
-            f.suptitle(title)
-        return results
-
-    # if strata is None, produce plot
+    # make color in puts consistent hex format
     if colors.is_color_like(with_condition_color):
         with_condition_color = colors.to_hex(with_condition_color)
     if colors.is_color_like(no_condition_color):
         no_condition_color = colors.to_hex(no_condition_color)
-    kmf = KaplanMeierFitter()
+    ## prepare data to be plotted; producing 3 outputs:
+    # - `condition`, series containing category labels to be plotted
+    # - `label_map` (mapping condition values to plot labels)
+    # - `color_map` (mapping condition values to plotted colors)
     if threshold is not None:
         is_median = threshold == "median"
         if is_median:
@@ -162,6 +101,8 @@ def plot_kmf(df,
         raise ValueError('Don\'t know how to plot data of type\
                          {}'.format(df[condition_col].dtype))
 
+    # produce kmf plot for each category (group) identified above
+    kmf = KaplanMeierFitter()
     grp_desc = list()
     grp_survival_data = dict()
     grp_event_data = dict()
@@ -181,31 +122,37 @@ def plot_kmf(df,
         else:
             ax = kmf.plot(show_censors=True, ci_show=ci_show, color=grp_color)
 
+    ## format the plot
     # Set the y-axis to range 0 to 1
     ax.set_ylim(0, 1)
     y_tick_vals = ax.get_yticks()
     ax.set_yticklabels(["%d" % int(y_tick_val * 100) for y_tick_val in y_tick_vals])
-
+    # plot title
     if title:
         ax.set_title(title)
     elif print_as_title:
         ax.set_title(' | '.join(grp_desc))
     else:
         [print(desc) for desc in grp_desc]
-
+    # axis labels
     if xlabel:
         ax.set_xlabel(xlabel)
     if ylabel:
         ax.set_ylabel(ylabel)
-
+    
+    ## summarize analytical version of results
+    ## again using same groups as are plotted
     if len(grp_names) == 2:
+        # use log-rank test for 2 groups
         results = logrank_test(grp_survival_data[grp_names[0]],
                                grp_survival_data[grp_names[1]],
                                event_observed_A=grp_event_data[grp_names[0]],
                                event_observed_B=grp_event_data[grp_names[1]])
     elif len(grp_names) == 1:
+        # no analytical result for 1 or 0 groups
         results = NullSurvivalResults()
     else:
+        # cox PH fitter for >2 groups
         cf = CoxPHFitter()
         cox_df = patsy.dmatrix('+'.join([condition_col, survival_col,
                                          censor_col]),
@@ -213,13 +160,146 @@ def plot_kmf(df,
         del cox_df['Intercept']
         results = cf.fit(cox_df, survival_col, event_col=censor_col)
         results.print_summary()
+    # add metadata to results object so caller can print them
     results.survival_data_series = grp_survival_data
     results.event_data_series = grp_event_data
     results.desc = grp_desc
     return results
 
+
+def plot_kmf(df,
+             condition_col,
+             censor_col,
+             survival_col,
+             strata_col=None,
+             threshold=None,
+             title=None,
+             xlabel=None,
+             ylabel=None,
+             ax=None,
+             with_condition_color="#B38600",
+             no_condition_color="#A941AC",
+             with_condition_label=None,
+             no_condition_label=None,
+             color_map=None,
+             label_map=None,
+             color_palette="Set1",
+             ci_show=False,
+             print_as_title=False):
+    """
+    Plot survival curves by splitting the dataset into two groups based on
+    condition_col. Report results for a log-rank test (if two groups are plotted)
+    or CoxPH survival analysis (if >2 groups) for association with survival.
+
+    Regarding definition of groups:
+        If condition_col is numeric, values are split into 2 groups.
+             - if threshold is defined, the groups are split on being > or < condition_col
+             - if threshold == 'median', the threshold is set to the median of condition_col
+        If condition_col is categorical or string, results are plotted for each unique value in the dataset.
+        If condition_col is None, results are plotted for all observations
+
+    Currently, if `strata_col` is given, the results are repeated among each stratum of the df.
+    A truly "stratified" analysis is not yet supported by may be soon.
+
+    Parameters
+    ----------
+        df: dataframe
+        condition_col: string, column which contains the condition to split on
+        survival_col: string, column which contains the survival time
+        censor_col: string,
+        strata_col: optional string, denoting column containing data to
+                    stratify by (default: None)
+        threshold: int or string, if int, condition_col is thresholded,
+                                  if 'median', condition_col thresholded
+                                  at its median
+                                  if 'median per-strata', & if stratified analysis
+                                  then condition_col thresholded by strata
+        title: Title for the plot, default None
+        ax: an existing matplotlib ax, optional, default None
+             note: not currently supported when `strata_col` is not None
+        with_condition_color: str, hex code color for the with-condition curve
+        no_condition_color: str, hex code color for the no-condition curve
+        with_condition_label: str, optional, label for TRUE condition case
+        no_condition_label: str, optional, label for FALSE condition case
+        color_map: dict, optional, mapping of hex-values to condition text
+          in the form of {value_name: color_hex_code}.
+          defaults to `sb.color_palette` using `default_color_palette` name,
+          or *_condition_color options in case of boolean operators.
+        label_map: dict, optional, mapping of labels to condition text.
+          defaults to "condition_name = condition_value", or *_condition_label
+          options in case of boolean operators.
+        color_palette: str, optional, name of sb.color_palette to use
+          if color_map not provided.
+        print_as_title: bool, optional, whether or not to print text
+          within the plot's title vs. stdout, default False
+    """
+    
+    # set reasonable default threshold value depending on type of condition_col
+    if threshold is None:
+        if df[condition_col].dtype != 'bool' and \
+            np.issubdtype(df[condition_col].dtype, np.number):
+                threshold = 'median'
+
+    # construct kwarg dict to pass to _plot_kmf_single.
+    # start with args that do not vary according to strata_col
+    arglist = dict(
+            condition_col=condition_col,
+            survival_col=survival_col,
+            censor_col=censor_col,
+            threshold=threshold,
+            with_condition_color=with_condition_color,
+            no_condition_color=no_condition_color,
+            with_condition_label=with_condition_label,
+            no_condition_label=no_condition_label,
+            color_map=color_map,
+            label_map=label_map,
+            xlabel=xlabel,
+            ylabel=ylabel,
+            ci_show=ci_show,
+            color_palette=color_palette,
+            print_as_title=print_as_title)
+
+    # if strata_col is None, pass all parameters to _plot_kmf_single
+    if strata_col is None:
+        arglist.update(dict(
+            df=df,
+            title=title,
+            ax=ax))
+        return _plot_kmf_single(**arglist)
+    else:
+        # prepare for stratified analysis
+        if threshold == 'median':
+            # by default, "median" threshold should be intra-strata median
+            arglist['threshold'] = df[condition_col].dropna().median()
+        elif threshold == 'median per-strata':
+            arglist['threshold'] = 'median'
+        # create axis / subplots for stratified results
+        if ax is not None:
+            raise ValueError('ax not supported with stratified analysis.')
+        n_strata = len(df[strata_col].unique())
+        f, ax = plt.subplots(n_strata, sharex=True)
+        # create results dict to hold per-strata results
+        results = dict()
+        # call _plot_kmf_single for each of the strata
+        for i, (strat_name, strat_df) in enumerate(df.groupby(strata_col)):
+            if n_strata == 1:
+                arglist['ax'] = ax
+            else:
+                arglist['ax'] = ax[i]
+            subtitle = "{}: {}".format(strata_col, strat_name)
+            arglist['title'] = subtitle
+            arglist['df'] = strat_df
+            results[subtitle] = plot_kmf(**arglist)
+            [print(desc) for desc in results[subtitle].desc]
+        if title:
+            f.suptitle(title)
+        return results
+
+
 class NullSurvivalResults(object):
-    pass
+    def __repr__(self):
+        return "No model fit."
+
 
 def logrank(df,
             condition_col,

--- a/cohorts/survival.py
+++ b/cohorts/survival.py
@@ -18,6 +18,7 @@ from lifelines import KaplanMeierFitter, CoxPHFitter
 from lifelines.statistics import logrank_test
 import matplotlib.colors as colors
 from matplotlib import pyplot as plt
+import numbers
 import numpy as np
 import seaborn as sb
 import patsy

--- a/cohorts/survival.py
+++ b/cohorts/survival.py
@@ -181,7 +181,6 @@ def plot_kmf(df,
     results.event_data_series = grp_event_data
     return results
 
-
 class NullSurvivalResults(object):
     pass
 

--- a/cohorts/survival.py
+++ b/cohorts/survival.py
@@ -23,7 +23,9 @@ import numpy as np
 import seaborn as sb
 import patsy
 from .rounding import float_str
+from .utils import get_logger
 
+logger = get_logger(__name__, level=logging.INFO)
 
 def _plot_kmf_single(df,
                      condition_col,

--- a/docs/quick-start.Rmd
+++ b/docs/quick-start.Rmd
@@ -1,0 +1,151 @@
+
+# Using cohorts
+
+[Cohorts](http://github.com/hammerlab/cohorts) is a library for analyzing and plotting clinical data, mutations and neoepitopes in patient cohorts.
+
+It calls out to external libraries like topiary and caches the results for easy manipulation.
+
+
+# Motivating use case
+
+The motivating use case for Cohorts is a clinical study for checkpoint blockade (ie cancer immunotherapy).
+
+These studies typically collect a wide range of data for each patient, such as:
+
+- clinical data (e.g. outcome, treatment assignment, gender, risk factors, etc)
+- whole-exome sequencing (WES) or whole-genome sequencing (WGS) data
+   - typically for tumor & normal samples
+- expression data (e.g. RNA-seq)
+- immune infiltrate data 
+- targeted sequencing data (e.g. IMPACT calls or foundation panel data)
+- etc.
+
+Data inputs are processed into clinically-relevant features, such as:
+
+- somatic mutations
+- predicted neoantigens
+- mutational signatures
+- tumor heterogeneity estimates
+- etc.
+
+Because of the computational overhead frequently involved in computing the above-mentioned 
+features, Cohorts caches these computed features by default. The [caching strategy](#caching-strategy)
+will be described in some detail below, but in general Cohorts uses file-based caching.
+
+Cohorts then provides utilities to aid in filtering, summarizing & evaluating these features and 
+their correlation with a variety of clinical outcomes in either a Survival-analysis context or 
+a logistic regression. 
+
+Clinical outcomes evaluated typically include survival, progression-free survival, durable clinical 
+benefit, RECIST, or mRECIST criteria.  
+
+We expect that the sets of input data, features & clinical outcome measures will not only 
+vary from cohort to cohort, but will also likely grow in variety over time. [Cohorts](http://github.com/hammerlab/cohorts) is designed with this flexibility in mind.
+
+
+# Design philosophy
+
+A `Cohort` is, at its most basic level, a collection of Patients. 
+
+At a minimum, each Patient has the following data elements: 
+
+ * id: unique identifier
+ * deceased: boolean indicating if patient deceased
+ * progressed: boolean indicating if patient progressed
+ * os: time (usually days) to death or censor event
+ * pfs: time (days) to progression, death or censor event
+
+The two pairs of endopint data (`os`,`deceased`) and (`pfs`, `progressed`) are used to define the primary endpoint(s) of the study, namely: 
+
+ * Overall Survival, and
+ * Progression-Free Survival
+
+### Minimal example
+
+To illustrate this in practice, let's simulate data for a few sample patients.
+
+```{python, engine.path='/Users/jacquelineburos/anaconda3/envs/py35/bin/python'}
+import cohorts
+
+```
+
+## Example with genetic data
+
+We can also use [pygdc](http://github.com/hammerlab/pygdc)'s `build_cohort` function to easily create a cohort from TCGA data.
+
+```{python, engine.path="/usr/local/bin/python"}
+import pygdc
+
+lung_cohort = pygdc.build_cohort(
+    primary_site='Lung', 
+    cohort_cache_dir='cache-dir')
+
+lung_cohort.plot_survival('age_at_diagnosis')
+```
+
+# Concepts
+
+## Filters
+
+## Provenance
+
+# Caching strategy
+
+For cohorts that include variants or Samples, the results can be summarized at various levels. 
+
+Many of these will save computed data for each patient in a pickled object, to be re-used on subsequent calls.
+
+Some examples of functions that cache results:
+
+   - `cohorts.load_effects()` -> computed variant effects are stored in `cached-effects`
+   - `cohorts.load_variants()` -> VariantCollection stored in `cached-variants`
+   - . etc.
+
+Cached objects are created when used. So, for example, if you only reference effects for a single patient, only those effects will be cached. 
+
+There is no automated checking of cached objects. To clear the cache, simply delete or rename the `cache-dir`.
+
+## Provenance files & Caching
+
+This leads to a possibility that cached objects of the same type but for different patients could have been generated in different environments.
+
+Consider, for example, the following scenario:
+   1. Initial analysis of cohort is performed on first 10 samples received. 
+      - results are cached under `variant-effects` for patients 1-10
+   2. *... several weeks go by while awaiting additional sample data ...*
+      - meanwhile, there have been updates to libraries such as `varcode` or `Cohorts`
+   3. Data for samples from patients 11-20 are recieved, plus updated sample calls for patients 1-10
+      - the analysis is re-run, with intention of updating data
+      - data for patients 1-10 are retreived from cache; data for patients 11-20 are generated & cached
+   4. The analysis loads data from the Cohort, which prints a summary of data sources
+      - the data frame hash will have been updated since the data summaries include sample data for addt'l 10 patients
+      - provenance_summary checks which versions of packages were used to generated cached object
+         - if inconsistent among patients within a data-type, reports an error. 
+         - otherwise, if inconsistent only between data-types, reports a warning
+         - if consistent across all patients & data-types, prints a summary for comparison to other analyses
+
+# Best Practices
+
+In general, we recommend creating a repository for each Cohort that is analyzed.
+
+Each Cohort should have several elements:
+
+   - source data files, or links to files (clinical data & samples)
+   - dedicated cache-dir
+   - an `init_cohort` script, to ensure consistent cohort settings across analyses
+   - accompanying analysis files
+
+Here are some examples of repositories using Cohorts:
+
+   - [tcga-blca](http://github.com/jburos/tcga-blca) repo, containing mock-analysis of TCGA-BLCA data & samples
+
+We have additionally created a [cookiecutter](https://github.com/audreyr/cookiecutter) template to set up a recommended directory structure for an analysis project using Cohorts.
+
+To use this, first install Cookiecutter. 
+
+Then :
+    
+    $ cookiecutter https://github.com/jburos/cookiecutter-cohort.git
+   
+And follow the prompts to create your project template.
+


### PR DESCRIPTION
Minor feature added to `plot_survival`, to support a `strata` keyword.

At the moment, this results in a separate survival plot or analysis being produced, one for each stratifying group. 

E.g.: 

![3538a6dce4da4be7a91a099012aa46c7 _screen 20shot 202017-07-18 20at 202 25 35 20pm](https://user-images.githubusercontent.com/923453/28333487-10300c02-6bc6-11e7-87f6-e2029eba43ce.png)


(note that I have greyed out the sample names although in reality they printed as text).