### PR TITLE
Expose gcloud utils

### DIFF
--- a/cohorts/__init__.py
+++ b/cohorts/__init__.py
@@ -16,6 +16,7 @@ from .cohort import Cohort
 from .patient import Patient
 from .sample import Sample
 from .dataframe_loader import DataFrameLoader
+from . import io
 
 from ._version import get_versions
 __version__ = get_versions()['version']

--- a/cohorts/__init__.py
+++ b/cohorts/__init__.py
@@ -20,4 +20,3 @@ from .dataframe_loader import DataFrameLoader
 from ._version import get_versions
 __version__ = get_versions()['version']
 del get_versions
-

--- a/cohorts/__init__.py
+++ b/cohorts/__init__.py
@@ -16,8 +16,8 @@ from .cohort import Cohort
 from .patient import Patient
 from .sample import Sample
 from .dataframe_loader import DataFrameLoader
-from . import io
 
 from ._version import get_versions
 __version__ = get_versions()['version']
 del get_versions
+

--- a/setup.py
+++ b/setup.py
@@ -69,5 +69,5 @@ if __name__ == "__main__":
         dependency_links=dependency_links,
         python_requires=">=3.3",
         long_description=readme,
-        packages=["cohorts"],
+        packages=["cohorts", "cohorts.io"],
     )


### PR DESCRIPTION
Currently, gcloud utils cannot be imported because they weren't included in setup.py. This PR includes them for use in certain projects.