### PR TITLE
add `join_on_left` parameter to dataframe_loader

### DIFF
--- a/cohorts/cohort.py
+++ b/cohorts/cohort.py
@@ -1298,7 +1298,6 @@ class Cohort(Collection):
                       on,
                       how="os",
                       survival_units="Days",
-                      strata=None,
                       ax=None,
                       ci_show=False,
                       with_condition_color="#B38600",
@@ -1318,8 +1317,6 @@ class Cohort(Collection):
             Whether to plot OS (overall survival) or PFS (progression free survival)
         survival_units : str
             Unit of time for the survival measure, i.e. Days or Months
-        strata : str
-            (optional) column name of stratifying variable
         ci_show : bool
             Display the confidence interval around the survival curve
         threshold : int or "median", optional
@@ -1346,7 +1343,6 @@ class Cohort(Collection):
             ylabel="Overall Survival (%)" if how == "os" else "Progression-Free Survival (%)",
             censor_col="deceased" if how == "os" else "progressed_or_deceased",
             survival_col=how,
-            strata_col=strata,
             threshold=threshold if threshold is not None else default_threshold,
             ax=ax,
             ci_show=ci_show,

--- a/cohorts/cohort.py
+++ b/cohorts/cohort.py
@@ -284,8 +284,8 @@ class Cohort(Collection):
             old_len_df = len(df)
             df = df.merge(
                 loaded_df,
-                left_on="patient_id",
-                right_on=df_loader.join_on,
+                left_on=df_loader.join_on_left,
+                right_on=df_loader.join_on_right,
                 how=join_how)
             print("%s join with %s: %d to %d rows" % (
                 join_how,
@@ -1298,6 +1298,7 @@ class Cohort(Collection):
                       on,
                       how="os",
                       survival_units="Days",
+                      strata=None,
                       ax=None,
                       ci_show=False,
                       with_condition_color="#B38600",
@@ -1317,6 +1318,8 @@ class Cohort(Collection):
             Whether to plot OS (overall survival) or PFS (progression free survival)
         survival_units : str
             Unit of time for the survival measure, i.e. Days or Months
+        strata : str
+            (optional) column name of stratifying variable
         ci_show : bool
             Display the confidence interval around the survival curve
         threshold : int or "median", optional
@@ -1343,6 +1346,7 @@ class Cohort(Collection):
             ylabel="Overall Survival (%)" if how == "os" else "Progression-Free Survival (%)",
             censor_col="deceased" if how == "os" else "progressed_or_deceased",
             survival_col=how,
+            strata_col=strata,
             threshold=threshold if threshold is not None else default_threshold,
             ax=ax,
             ci_show=ci_show,

--- a/cohorts/dataframe_loader.py
+++ b/cohorts/dataframe_loader.py
@@ -28,7 +28,7 @@ class DataFrameLoader(object):
         The column of the `DataFrame` to join on (i.e. the patient
         ID column name).
     join_on_left: str
-        The corresponding column in the `cohorts.Patient.additional_data` 
+        The corresponding column in the `cohorts.Patient.additional_data`
 	to join on, if not the `id` (which is the default).
     """
     def __init__(self,
@@ -39,7 +39,7 @@ class DataFrameLoader(object):
                  join_on_left="patient_id"):
         self.name = name
         self.load_dataframe = load_dataframe
-        if join_on:
+        if join_on is not None:
             warnings.warn("`join_on` parameter is deprecated. Please use `join_on_right` instead.", DeprecationWarning)
             self.join_on_right = join_on
         else:

--- a/cohorts/dataframe_loader.py
+++ b/cohorts/dataframe_loader.py
@@ -24,9 +24,12 @@ class DataFrameLoader(object):
         The name of the dataframe, to easily reference it.
     load_dataframe : function
         A function that returns the `DataFrame` object.
-    join_on : str
+    join_on_right : str
         The column of the `DataFrame` to join on (i.e. the patient
         ID column name).
+    join_on_left: str
+        The corresponding column in the `cohorts.Patient.additional_data` 
+	to join on, if not the `id` (which is the default).
     """
     def __init__(self,
                  name,
@@ -37,9 +40,8 @@ class DataFrameLoader(object):
         self.name = name
         self.load_dataframe = load_dataframe
         if join_on:
-            warnings.warn("`join_on` parameter is deprecated. Please use `join_on_right` instead.", warnings.DeprecationWarning)
-            if join_on_right:
-                ValueError("Both join_on_right & join_on given, but only one is supported.")
+            warnings.warn("`join_on` parameter is deprecated. Please use `join_on_right` instead.", DeprecationWarning)
             self.join_on_right = join_on
+        else:
+            self.join_on_right = join_on_right
         self.join_on_left = join_on_left
-        self.join_on_right = join_on_right

--- a/cohorts/dataframe_loader.py
+++ b/cohorts/dataframe_loader.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import warnings
+
 class DataFrameLoader(object):
     """
     Wraps a `DataFrame` with some information on how to join it.
@@ -29,9 +31,15 @@ class DataFrameLoader(object):
     def __init__(self,
                  name,
                  load_dataframe,
-                 join_on="patient_id",
+                 join_on=None,
+                 join_on_right="patient_id",
                  join_on_left="patient_id"):
         self.name = name
         self.load_dataframe = load_dataframe
+        if join_on:
+            warnings.warn("`join_on` parameter is deprecated. Please use `join_on_right` instead.", warnings.DeprecationWarning)
+            if join_on_right:
+                ValueError("Both join_on_right & join_on given, but only one is supported.")
+            self.join_on_right = join_on
         self.join_on_left = join_on_left
-        self.join_on_right = join_on
+        self.join_on_right = join_on_right

--- a/cohorts/dataframe_loader.py
+++ b/cohorts/dataframe_loader.py
@@ -29,7 +29,9 @@ class DataFrameLoader(object):
     def __init__(self,
                  name,
                  load_dataframe,
-                 join_on="patient_id"):
+                 join_on="patient_id",
+                 join_on_left="patient_id"):
         self.name = name
         self.load_dataframe = load_dataframe
-        self.join_on = join_on
+        self.join_on_left = join_on_left
+        self.join_on_right = join_on


### PR DESCRIPTION
Allows a dataframe to merge with the cohort on a field other than patient_id.

In one of our projects, the extraneous data are sometimes labelled by sample_id, which is a different identifier than patient id. Allowing a join_on_left parameter seems cleaner than merging-in a patient_id identifier for each of these external dataframes.

(I'm not really happy with the name of this parameter, but the functionality would be useful).