### PR TITLE
add get-blob method to gcio

### DIFF
--- a/cohorts/io/gcloud_storage.py
+++ b/cohorts/io/gcloud_storage.py
@@ -135,6 +135,12 @@ class GoogleStorageIO:
         # corrupted/incomplete data to be around as much as possible.
         return os.rename(tmp_file_path, localpath)
 
+    def get_blob(self, gsuri):
+        bucket_name, gs_rel_path = self.parse_uri(gsuri)
+        bucket = self._client.get_bucket(bucket_name)
+        ablob = bucket.get_blob(gs_rel_path)
+        return ablob
+
 
 class GoogleStorageFile(object):
     """


### PR DESCRIPTION
Very minor PR to add `get_blob` method. 

This allows one to use other methods on the blob (e.g. checksum, or get filesize) that are not directly supported by our `gcloud_storage.py` methods. 

In my scenario, I wanted to test for a filesize of 0 in order to handle an edge case in my download-from-gcloud-to-local-device code. The empty files failed to download. 