### PR TITLE
Report on but do not error when patient has no RNA data

### DIFF
--- a/cohorts/cohort.py
+++ b/cohorts/cohort.py
@@ -975,16 +975,20 @@ class Cohort(Collection):
 
         dfs = {}
         for patient in self.iter_patients(patients):
-            df_epitopes = self._load_single_patient_neoantigens(
-                patient=patient,
-                only_expressed=only_expressed,
-                epitope_lengths=epitope_lengths,
-                ic50_cutoff=ic50_cutoff,
-                process_limit=process_limit,
-                max_file_records=max_file_records,
-                filter_fn=filter_fn)
-            if df_epitopes is not None:
-                dfs[patient.id] = df_epitopes
+            try:
+                df_epitopes = self._load_single_patient_neoantigens(
+                    patient=patient,
+                    only_expressed=only_expressed,
+                    epitope_lengths=epitope_lengths,
+                    ic50_cutoff=ic50_cutoff,
+                    process_limit=process_limit,
+                    max_file_records=max_file_records,
+                    filter_fn=filter_fn)
+            except BamFileNotFound as e:
+                logger.warning(str(e))
+            else:
+                if df_epitopes is not None:
+                    dfs[patient.id] = df_epitopes
         return dfs
 
     def _load_single_patient_neoantigens(self, patient, only_expressed, epitope_lengths,

--- a/cohorts/cohort.py
+++ b/cohorts/cohort.py
@@ -60,6 +60,7 @@ from .varcode_utils import (filter_variants, filter_effects,
 from .variant_filters import no_filter
 from .styling import set_styling
 from . import variant_filters
+from .errors import BamFileNotFound, TumorBamFileNotFound, RNABamFileNotFound
 
 logger = get_logger(__name__, level=logging.INFO)
 

--- a/cohorts/cohort.py
+++ b/cohorts/cohort.py
@@ -60,6 +60,7 @@ from .varcode_utils import (filter_variants, filter_effects,
 from .variant_filters import no_filter
 from .styling import set_styling
 from . import variant_filters
+from .errors import BamFileNotFound, TumorBamFileNotFound, RNABamFileNotFound
 
 logger = get_logger(__name__, level=logging.INFO)
 
@@ -1098,9 +1099,9 @@ class Cohort(Collection):
         import logging
         logging.disable(logging.INFO)
         if patient.tumor_sample is None:
-            raise ValueError("Patient %s has no tumor sample" % patient.id)
+            raise TumorBamFileNotFound(patient_id=patient.id)
         if patient.tumor_sample.bam_path_rna is None:
-            raise ValueError("Patient %s has no tumor RNA BAM path" % patient.id)
+            raise RNABamFileNotFound(patient_id=patient.id)
         rna_bam_file = AlignmentFile(patient.tumor_sample.bam_path_rna)
 
         # To ensure that e.g. 8-11mers overlap substitutions, we need at least this

--- a/cohorts/cohort.py
+++ b/cohorts/cohort.py
@@ -60,7 +60,6 @@ from .varcode_utils import (filter_variants, filter_effects,
 from .variant_filters import no_filter
 from .styling import set_styling
 from . import variant_filters
-from .errors import BamFileNotFound, TumorBamFileNotFound, RNABamFileNotFound
 
 logger = get_logger(__name__, level=logging.INFO)
 

--- a/cohorts/errors.py
+++ b/cohorts/errors.py
@@ -4,29 +4,28 @@ class BamFileNotFound(Exception):
     def __init__(self, filepath=None, patient_id=None, filetype=None):
         self.filepath = filepath
         self.patient_id = patient_id
-        self.filetype = 'Bamfile' if filetype is None else filetype
+        self.filetype = "Bamfile" if filetype is None else filetype
 
     def __str__(self):
         if self.patient_id is not None:
-            patient_str = 'Patient {}'.format(self.patient_id)
+            patient_str = "Patient {}".format(self.patient_id)
         else:
-            patient_str = 'Patient'
+            patient_str = "Patient"
 
         if self.filepath is not None:
-            print_str = 'The {} ({}) for {} was not found.'.format(self.filetype, repr(self.filepath), patient_str)
+            print_str = "The {} ({}) for {} was not found.".format(self.filetype, repr(self.filepath), patient_str)
         else:
-            print_str = '{} has no {}.'.format(patient_str, self.filetype)
+            print_str = "{} has no {}.".format(patient_str, self.filetype)
         return print_str
 
 class RNABamFileNotFound(BamFileNotFound):
-    def __init__(self, filetype='tumor RNA Bamfile', *args, **kwargs):
+    def __init__(self, filetype="tumor RNA Bamfile", *args, **kwargs):
         super().__init__(filetype=filetype, *args, **kwargs)
 
 class TumorBamFileNotFound(BamFileNotFound):
-    def __init__(self, filetype='tumor sample bamfile', *args, **kwargs):
+    def __init__(self, filetype="tumor sample bamfile", *args, **kwargs):
         super().__init__(filetype=filetype, *args, **kwargs)
 
 class NormalBamFileNotFound(BamFileNotFound):
-    def __init__(self, filetype='normal sample bamfile', *args, **kwargs):
+    def __init__(self, filetype="normal sample bamfile", *args, **kwargs):
         super().__init__(filetype=filetype, *args, **kwargs)
-

--- a/cohorts/errors.py
+++ b/cohorts/errors.py
@@ -1,10 +1,10 @@
 
-class BamFileNotFound(Exception):
+class MissingData(Exception):
 
-    def __init__(self, filepath=None, patient_id=None, filetype=None):
+    def __init__(self, filepath=None, patient_id=None, filetype='Data'):
         self.filepath = filepath
         self.patient_id = patient_id
-        self.filetype = "Bamfile" if filetype is None else filetype
+        self.filetype = filetype
 
     def __str__(self):
         if self.patient_id is not None:
@@ -18,14 +18,26 @@ class BamFileNotFound(Exception):
             print_str = "{} has no {}.".format(patient_str, self.filetype)
         return print_str
 
-class RNABamFileNotFound(BamFileNotFound):
+class MissingBamFile(MissingData):
+    def __init__(self, filetype='Bamfile', *args, **kwargs):
+        super().__init__(filetype=filetype, *args, **kwargs)
+
+class MissingRNABamFile(MissingBamFile):
     def __init__(self, filetype="tumor RNA Bamfile", *args, **kwargs):
         super().__init__(filetype=filetype, *args, **kwargs)
 
-class TumorBamFileNotFound(BamFileNotFound):
+class MissingTumorBamFile(MissingBamFile):
     def __init__(self, filetype="tumor sample bamfile", *args, **kwargs):
         super().__init__(filetype=filetype, *args, **kwargs)
 
-class NormalBamFileNotFound(BamFileNotFound):
+class MissingNormalBamFile(MissingBamFile):
     def __init__(self, filetype="normal sample bamfile", *args, **kwargs):
+        super().__init__(filetype=filetype, *args, **kwargs)
+
+class MissingHLAType(MissingData):
+    def __init__(self, filetype="HLA alleles", *args, **kwargs):
+        super().__init__(filetype=filetype, *args, **kwargs)
+
+class MissingVariantFile(MissingData):
+    def __init__(self, filetype="vcf/maf files", *args, **kwargs):
         super().__init__(filetype=filetype, *args, **kwargs)

--- a/cohorts/errors.py
+++ b/cohorts/errors.py
@@ -1,0 +1,32 @@
+
+class BamFileNotFound(Exception):
+
+    def __init__(self, filepath=None, patient_id=None, filetype=None):
+        self.filepath = filepath
+        self.patient_id = patient_id
+        self.filetype = 'Bamfile' if filetype is None else filetype
+
+    def __str__(self):
+        if self.patient_id is not None:
+            patient_str = 'Patient {}'.format(self.patient_id)
+        else:
+            patient_str = 'Patient'
+
+        if self.filepath is not None:
+            print_str = 'The {} ({}) for {} was not found.'.format(self.filetype, repr(self.filepath), patient_str)
+        else:
+            print_str = '{} has no {}.'.format(patient_str, self.filetype)
+        return print_str
+
+class RNABamFileNotFound(BamFileNotFound):
+    def __init__(self, filetype='tumor RNA Bamfile', *args, **kwargs):
+        super().__init__(filetype=filetype, *args, **kwargs)
+
+class TumorBamFileNotFound(BamFileNotFound):
+    def __init__(self, filetype='tumor sample bamfile', *args, **kwargs):
+        super().__init__(filetype=filetype, *args, **kwargs)
+
+class NormalBamFileNotFound(BamFileNotFound):
+    def __init__(self, filetype='normal sample bamfile', *args, **kwargs):
+        super().__init__(filetype=filetype, *args, **kwargs)
+

--- a/cohorts/varcode_utils.py
+++ b/cohorts/varcode_utils.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from varcode import EffectCollection, Variant
-from .errors import BamFileNotFound
+from .errors import MissingBamFile
 import logging
 
 logger = logging.getLogger(__name__)
@@ -107,9 +107,12 @@ def filter_variants(variant_collection, patient, filter_fn, **kwargs):
                         patient=patient,
                         ), **kwargs)
             ])
-        except BamFileNotFound as e:
-            logger.warning(repr(e))
-            return None
+        except MissingBamFile as e:
+            if patient.cohort.fail_on_missing_bams:
+                raise
+            else:
+                logger.info(repr(e))
+                return None
     else:
         return variant_collection
 

--- a/cohorts/varcode_utils.py
+++ b/cohorts/varcode_utils.py
@@ -111,7 +111,7 @@ def filter_variants(variant_collection, patient, filter_fn, **kwargs):
             if patient.cohort.fail_on_missing_bams:
                 raise
             else:
-                logger.info(repr(e))
+                logger.info(str(e))
                 return None
     else:
         return variant_collection
@@ -142,7 +142,7 @@ def filter_effects(effect_collection, variant_collection, patient, filter_fn, **
                         variant_collection=variant_collection,
                         patient=patient), **kwargs)])
         except MissingBamFile as e:
-            logger.warning(repr(e))
+            logger.warning(str(e))
             return None
     else:
         return effect_collection
@@ -160,7 +160,7 @@ def filter_neoantigens(neoantigens_df, variant_collection, patient, filter_fn):
                 reduce=True)
             return neoantigens_df[filter_mask]
         except MissingBamFile as e:
-            logger.warning(repr(e))
+            logger.warning(str(e))
             return None
     else:
         return neoantigens_df

--- a/cohorts/varcode_utils.py
+++ b/cohorts/varcode_utils.py
@@ -141,7 +141,7 @@ def filter_effects(effect_collection, variant_collection, patient, filter_fn, **
                         effect=effect,
                         variant_collection=variant_collection,
                         patient=patient), **kwargs)])
-        except BamFileNotFound as e:
+        except MissingBamFile as e:
             logger.warning(repr(e))
             return None
     else:
@@ -159,7 +159,7 @@ def filter_neoantigens(neoantigens_df, variant_collection, patient, filter_fn):
                 # reduce ensures that an empty result is a Series vs. a DataFrame
                 reduce=True)
             return neoantigens_df[filter_mask]
-        except BamFileNotFound as e:
+        except MissingBamFile as e:
             logger.warning(repr(e))
             return None
     else:

--- a/cohorts/variant_filters.py
+++ b/cohorts/variant_filters.py
@@ -19,6 +19,7 @@ from varcode import Variant
 from varcode.common import memoize
 import pandas as pd
 from os import path
+from .errors import MissingBamFile
 
 logger = get_logger(__name__)
 
@@ -60,10 +61,18 @@ def expressed_variant_set(cohort, patient, variant_collection):
     # TODO: we're currently using the same isovar cache that we use for expressed
     # neoantigen prediction; so we pass in the same epitope lengths.
     # This is hacky and should be addressed.
-    df_isovar = patient.cohort.load_single_patient_isovar(
-        patient=patient,
-        variants=variant_collection,
-        epitope_lengths=[8, 9, 10, 11])
+    try:
+        df_isovar = patient.cohort.load_single_patient_isovar(
+            patient=patient,
+            variants=variant_collection,
+            epitope_lengths=[8, 9, 10, 11])
+    except MissingBamFile as e:
+        if cohort.fail_on_missing_bams:
+            raise
+        else:
+            logger.info(str(e))
+            return None
+
     expressed_variant_set = set()
     for _, row in df_isovar.iterrows():
         expressed_variant = Variant(contig=row["chr"],

--- a/cohorts/variant_filters.py
+++ b/cohorts/variant_filters.py
@@ -14,7 +14,6 @@
 
 from .variant_stats import variant_stats_from_variant
 from .utils import get_logger
-from .errors import RNABamFileNotFound
 
 from varcode import Variant
 from varcode.common import memoize

--- a/cohorts/variant_filters.py
+++ b/cohorts/variant_filters.py
@@ -61,14 +61,10 @@ def expressed_variant_set(cohort, patient, variant_collection):
     # TODO: we're currently using the same isovar cache that we use for expressed
     # neoantigen prediction; so we pass in the same epitope lengths.
     # This is hacky and should be addressed.
-    try:
-        df_isovar = patient.cohort.load_single_patient_isovar(
-            patient=patient,
-            variants=variant_collection,
-            epitope_lengths=[8, 9, 10, 11])
-    except RNABamFileNotFound as e:
-        logger.debug('caught exception: {}'.format(repr(e)))
-        return None
+    df_isovar = patient.cohort.load_single_patient_isovar(
+        patient=patient,
+        variants=variant_collection,
+        epitope_lengths=[8, 9, 10, 11])
     expressed_variant_set = set()
     for _, row in df_isovar.iterrows():
         expressed_variant = Variant(contig=row["chr"],


### PR DESCRIPTION
Here I'm trying to achieve a goal of allowing an analysis on a cohort where some but not all records have RNA sequencing data. Currently, if one is using a summary function like `cohorts.functions.expressed_missense_snv_count`, you will see an exception if some but not all records have RNA expression data. 

Instead, we want to print a warning for these patients and populate the resulting df with `np.NaN` for any patient that does not contain RNA sequencing data where the filter function depends on it. This behavior would then be consistent with (for example) that of other summary functions like `missense_snv_count` for patients that do not have VCF files.

**Aside**: The correct way to handle this in most situations is to require that the cohort be filtered to those `Patient`s having RNA data prior to analysis. This would make the exception desirable. However there are scenarios (like when using `as_dataframe`) where one might desire a different behavior. This however, runs the risk of a user ignoring the INFO messages & proceeding with analysis in error. This might be something we want to allow the user to configure, ie whether to allow NaN values in the cohort or not. 

At any rate, for now, this PR does a few things:

1. Create new error classes for missing BAM files of various types
2. Catch those errors if they are used to filter variants or effects (not sure if this should apply to polyphen?)
3. Report those errors as `info` using the logger.

Also, for the sake of consistency, this PR:

1. Modifies earlier print statements when VCFs are not found for a patient to also use these error classes & report as INFO using the logger (previously these were print statements).

Note that I refactored some parts of the `Cohort._load_single_patient_variants` and `Cohort._load_single_patient_effects` in order to throw & report on these scenarios. 

