### PR TITLE
Fix effect priority caching

### DIFF
--- a/cohorts/cohort.py
+++ b/cohorts/cohort.py
@@ -826,14 +826,14 @@ class Cohort(Collection):
         if variants is None:
             return None
 
-        def top_priority_maybe(effects):
+        def top_priority_maybe(effect_collection):
             """
             Always (unless all_effects=True) take the top priority effect per variant
             so we end up with a single effect per variant.
             """
             if all_effects:
-                return effects
-            return EffectCollection(list(effects.top_priority_effect_per_variant().values()))
+                return effect_collection
+            return EffectCollection(list(effect_collection.top_priority_effect_per_variant().values()))
 
         if only_nonsynonymous:
             cached = self.load_from_cache(self.cache_names["nonsynonymous_effect"], patient.id, cached_file_name)

--- a/test/test_effects_caching.py
+++ b/test/test_effects_caching.py
@@ -24,8 +24,7 @@ def test_effects_priority_caching():
     Make sure that effects are cached such that they are not filtered
     prematurely. See https://github.com/hammerlab/cohorts/issues/252.
     """
-    cohort_initial = None
-    cohort_reloaded = None
+    cohort = None
     try:
         # This variant has IntronicSpliceSite, Subsitution effects, and more.
         variant = Variant(contig=3, start=20212211, ref="C", alt="T", ensembl=75)
@@ -34,6 +33,7 @@ def test_effects_priority_caching():
         cohort = Cohort(
             patients=[patient],
             cache_dir=cohort_cache_path)
+        cohort.clear_caches()
 
         # All of the effects.
         effects = cohort.load_effects(all_effects=True)[patient.id]
@@ -76,7 +76,5 @@ def test_effects_priority_caching():
         effects = cohort.load_effects(all_effects=True, only_nonsynonymous=True)[patient.id]
         eq_(len(effects), 6)
     finally:
-        if cohort_initial is not None:
-            cohort_initial.clear_caches()
-        if cohort_reloaded is not None:
-            cohort_reloaded.clear_caches()
+        if cohort is not None:
+            cohort.clear_caches()

--- a/test/test_effects_caching.py
+++ b/test/test_effects_caching.py
@@ -33,48 +33,49 @@ def test_effects_priority_caching():
         cohort = Cohort(
             patients=[patient],
             cache_dir=cohort_cache_path)
-        cohort.clear_caches()
 
         # All of the effects.
-        effects = cohort.load_effects(all_effects=True)[patient.id]
-        eq_(len(effects), 15)
-        # Try again, pulling from the cache now.
-        effects = cohort.load_effects(all_effects=True)[patient.id]
-        eq_(len(effects), 15)
-
-        # Clear the cache to compare creating from scratch vs. cache-pull results again.
         cohort.clear_caches()
+        for i in range(2):
+            effects = cohort.load_effects(all_effects=True)[patient.id]
+            eq_(len(effects), 15)
 
         # Top priority effect.
-        effects = cohort.load_effects()[patient.id]
-        eq_(len(effects), 1)
-        eq_(type(effects[0]), IntronicSpliceSite)
-        # Try again, pulling from the cache now.
-        effects = cohort.load_effects()[patient.id]
-        eq_(len(effects), 1)
-        eq_(type(effects[0]), IntronicSpliceSite)
+        cohort.clear_caches()
+        for i in range(2):
+            effects = cohort.load_effects()[patient.id]
+            eq_(len(effects), 1)
+            eq_(type(effects[0]), IntronicSpliceSite)
 
         def missense_snv_filter(filterable_effect):
             return (type(filterable_effect.effect) == Substitution and
                     filterable_effect.variant.is_snv)
 
         # All missense SNV effects, from the large cache.
-        effects = cohort.load_effects(all_effects=True, filter_fn=missense_snv_filter)[patient.id]
-        eq_(len(effects), 6)
+        cohort.clear_caches()
+        for i in range(2):
+            effects = cohort.load_effects(all_effects=True, filter_fn=missense_snv_filter)[patient.id]
+            eq_(len(effects), 6)
 
         # Top missense SNV effect, from the large cache.
-        effects = cohort.load_effects(filter_fn=missense_snv_filter)[patient.id]
-        eq_(len(effects), 1)
-        eq_(type(effects[0]), Substitution)
+        cohort.clear_caches()
+        for i in range(2):
+            effects = cohort.load_effects(filter_fn=missense_snv_filter)[patient.id]
+            eq_(len(effects), 1)
+            eq_(type(effects[0]), Substitution)
 
         # Top missense SNV effects, from the small nonsynonymous cache.
-        effects = cohort.load_effects(only_nonsynonymous=True, filter_fn=missense_snv_filter)[patient.id]
-        eq_(len(effects), 1)
-        eq_(type(effects[0]), Substitution)
+        cohort.clear_caches()
+        for i in range(2):
+            effects = cohort.load_effects(only_nonsynonymous=True, filter_fn=missense_snv_filter)[patient.id]
+            eq_(len(effects), 1)
+            eq_(type(effects[0]), Substitution)
 
         # All nonsynonymous effects, from the small nonsynonymous cache.
-        effects = cohort.load_effects(all_effects=True, only_nonsynonymous=True)[patient.id]
-        eq_(len(effects), 6)
+        cohort.clear_caches()
+        for i in range(2):
+            effects = cohort.load_effects(all_effects=True, only_nonsynonymous=True)[patient.id]
+            eq_(len(effects), 6)
     finally:
         if cohort is not None:
             cohort.clear_caches()

--- a/test/test_effects_caching.py
+++ b/test/test_effects_caching.py
@@ -1,0 +1,78 @@
+# Copyright (c) 2017. Mount Sinai School of Medicine
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from . import generated_data_path
+from cohorts import Patient, Cohort
+from varcode import Variant, VariantCollection
+from varcode.effects import Substitution, IntronicSpliceSite
+import pandas as pd
+from nose.tools import eq_, ok_
+
+def test_effects_priority_caching():
+    """
+    Make sure that effects are cached such that they are not filtered
+    prematurely. See https://github.com/hammerlab/cohorts/issues/252.
+    """
+    cohort = None
+    try:
+        # This variant has IntronicSpliceSite, Subsitution effects, and more.
+        variant = Variant(contig=3, start=20212211, ref="C", alt="T", ensembl=75)
+        patient = Patient(id="patient", os=3, pfs=2, deceased=False, progressed=False, variants=VariantCollection([variant]))
+        cohort_cache_path = generated_data_path("cache")
+        cohort_initial = Cohort(
+            patients=[patient],
+            cache_dir=cohort_cache_path)
+
+        def test_cohort(cohort):
+            # All of the effects.
+            effects = cohort.load_effects(all_effects=True)[patient.id]
+            eq_(len(effects), 15)
+
+            # Top priority effect.
+            effects = cohort.load_effects()[patient.id]
+            eq_(len(effects), 1)
+            eq_(type(effects[0]), IntronicSpliceSite)
+
+            def missense_snv_filter(filterable_effect):
+                return (type(filterable_effect.effect) == Substitution and
+                        filterable_effect.variant.is_snv)
+
+            # All missense SNV effects, from the large cache.
+            effects = cohort.load_effects(all_effects=True, filter_fn=missense_snv_filter)[patient.id]
+            eq_(len(effects), 6)
+
+            # Top missense SNV effect, from the large cache.
+            effects = cohort.load_effects(filter_fn=missense_snv_filter)[patient.id]
+            eq_(len(effects), 1)
+            eq_(type(effects[0]), Substitution)
+
+            # Top missense SNV effects, from the small nonsynonymous cache.
+            effects = cohort.load_effects(only_nonsynonymous=True, filter_fn=missense_snv_filter)[patient.id]
+            eq_(len(effects), 1)
+            eq_(type(effects[0]), Substitution)
+
+            # All nonsynonymous effects, from the small nonsynonymous cache.
+            effects = cohort.load_effects(all_effects=True, only_nonsynonymous=True)[patient.id]
+            eq_(len(effects), 6)
+
+        test_cohort(cohort_initial)
+
+        cohort_reloaded = Cohort(
+            patients=[patient],
+            cache_dir=cohort_cache_path)
+
+        test_cohort(cohort_reloaded)
+    finally:
+        if cohort is not None:
+            cohort.clear_caches()


### PR DESCRIPTION
In this PR, fixes for: https://github.com/hammerlab/cohorts/issues/253 and https://github.com/hammerlab/cohorts/issues/252

Instead of an "all_effects" cache, we now remove priority filtering from the small nonsyn. cache and the larger effects cache. If `all_effects` is true, we don't do priority filtering after generating our collections or pulling from the cache; otherwise, we do.

Tried to test this pretty aggressively.